### PR TITLE
feat(meetings): add X-Service-Secret header for civic.band API requests

### DIFF
--- a/meetings/services.py
+++ b/meetings/services.py
@@ -7,6 +7,7 @@ from datetime import date
 from typing import Any
 
 import httpx
+from django.conf import settings
 from django.db import transaction
 from django.utils import timezone
 
@@ -106,7 +107,13 @@ def _backfill_document_type(
     base_url = f"https://{muni.subdomain}.civic.band/meetings/{table_name}.json"
 
     try:
-        with httpx.Client(timeout=timeout) as client:
+        # Build headers with service secret for authentication
+        headers = {}
+        service_secret = getattr(settings, "CORKBOARD_SERVICE_SECRET", "")
+        if service_secret:
+            headers["X-Service-Secret"] = service_secret
+
+        with httpx.Client(timeout=timeout, headers=headers) as client:
             # Start with the first page
             url = f"{base_url}?_size=1000"
 


### PR DESCRIPTION
## Summary

- Adds `X-Service-Secret` header to all civic.band datasette API requests
- Uses the existing `CORKBOARD_SERVICE_SECRET` environment variable
- Prepares civic-observer for when API key checking is deployed on civicband

## Changes

The backfill service now includes the service secret header when fetching meeting data from civic.band. If the secret is not configured, requests continue without the header (backwards compatible).

## Test plan

- [x] All existing tests pass
- [ ] Deploy and verify backfill still works with `CORKBOARD_SERVICE_SECRET` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)