### PR TITLE
fix(searches): add muni property to Search model for template compatibility

### DIFF
--- a/searches/models.py
+++ b/searches/models.py
@@ -139,6 +139,11 @@ class Search(TimeStampedModel):
         verbose_name_plural = "Searches"
         ordering = ["-created"]
 
+    @property
+    def muni(self) -> Muni | None:
+        """Return the first municipality for backwards compatibility with templates."""
+        return self.municipalities.first()
+
     def __str__(self) -> str:
         if self.search_term:
             munis = self.municipalities.all()[:2]

--- a/templates/searches/savedsearch_confirm_delete.html
+++ b/templates/searches/savedsearch_confirm_delete.html
@@ -51,7 +51,9 @@
                             </div>
                             <div class="ml-3">
                                 <h4 class="text-lg font-semibold text-gray-900">{{ object.name }}</h4>
-                                <p class="text-sm text-gray-600">{{ object.search.muni.name }}, {{ object.search.muni.state }}</p>
+                                {% with muni=object.search.muni %}
+                                    <p class="text-sm text-gray-600">{% if muni %}{{ muni.name }}, {{ muni.state }}{% else %}All municipalities{% endif %}</p>
+                                {% endwith %}
                             </div>
                         </div>
 

--- a/templates/searches/savedsearch_edit.html
+++ b/templates/searches/savedsearch_edit.html
@@ -39,7 +39,13 @@
                 </div>
 
             <!-- Municipality Field -->
-                {% include "searches/partials/municipality_searchable_field.html" with field_name="municipality" field_id=form.municipality.id_for_label field_label=form.municipality.label field_help_text=form.municipality.help_text field_errors=form.municipality.errors field_value=form.municipality.value field_display=form.instance.search.muni.name|add:", "|add:form.instance.search.muni.state %}
+                {% with muni=form.instance.search.muni %}
+                    {% if muni %}
+                        {% include "searches/partials/municipality_searchable_field.html" with field_name="municipality" field_id=form.municipality.id_for_label field_label=form.municipality.label field_help_text=form.municipality.help_text field_errors=form.municipality.errors field_value=form.municipality.value field_display=muni.name|add:", "|add:muni.state %}
+                    {% else %}
+                        {% include "searches/partials/municipality_searchable_field.html" with field_name="municipality" field_id=form.municipality.id_for_label field_label=form.municipality.label field_help_text=form.municipality.help_text field_errors=form.municipality.errors field_value=form.municipality.value field_display="" %}
+                    {% endif %}
+                {% endwith %}
 
             <!-- Search Options -->
                 <div class="bg-gray-50 rounded-lg p-4">

--- a/tests/searches/test_views.py
+++ b/tests/searches/test_views.py
@@ -1,0 +1,166 @@
+"""Tests for saved search views to ensure templates render correctly."""
+
+import pytest
+from django.urls import reverse
+
+from tests.factories import MuniFactory, SavedSearchFactory, UserFactory
+
+
+@pytest.mark.django_db
+class TestSavedSearchListView:
+    def test_list_view_renders(self, client):
+        """Test saved search list page renders for authenticated user."""
+        user = UserFactory()
+        client.force_login(user)
+
+        response = client.get(reverse("searches:savedsearch-list"))
+
+        assert response.status_code == 200
+
+    def test_list_view_with_saved_searches(self, client):
+        """Test list view renders with saved searches."""
+        user = UserFactory()
+        muni = MuniFactory()
+        saved_search = SavedSearchFactory(user=user)
+        saved_search.search.municipalities.add(muni)
+
+        client.force_login(user)
+
+        response = client.get(reverse("searches:savedsearch-list"))
+
+        assert response.status_code == 200
+        assert saved_search.name in response.content.decode()
+
+
+@pytest.mark.django_db
+class TestSavedSearchDetailView:
+    def test_detail_view_renders(self, client):
+        """Test saved search detail page renders."""
+        user = UserFactory()
+        muni = MuniFactory()
+        saved_search = SavedSearchFactory(user=user)
+        saved_search.search.municipalities.add(muni)
+
+        client.force_login(user)
+
+        response = client.get(
+            reverse("searches:savedsearch-detail", kwargs={"pk": saved_search.pk})
+        )
+
+        assert response.status_code == 200
+        assert saved_search.name in response.content.decode()
+
+    def test_detail_view_without_municipality(self, client):
+        """Test detail view renders even without a municipality."""
+        user = UserFactory()
+        saved_search = SavedSearchFactory(user=user)
+        # Don't add any municipalities
+
+        client.force_login(user)
+
+        response = client.get(
+            reverse("searches:savedsearch-detail", kwargs={"pk": saved_search.pk})
+        )
+
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db
+class TestSavedSearchEditView:
+    def test_edit_view_renders(self, client):
+        """Test saved search edit page renders."""
+        user = UserFactory()
+        muni = MuniFactory()
+        saved_search = SavedSearchFactory(user=user)
+        saved_search.search.municipalities.add(muni)
+
+        client.force_login(user)
+
+        response = client.get(
+            reverse("searches:savedsearch-update", kwargs={"pk": saved_search.pk})
+        )
+
+        assert response.status_code == 200
+
+    def test_edit_view_without_municipality(self, client):
+        """Test edit view renders even without a municipality."""
+        user = UserFactory()
+        saved_search = SavedSearchFactory(user=user)
+        # Don't add any municipalities
+
+        client.force_login(user)
+
+        response = client.get(
+            reverse("searches:savedsearch-update", kwargs={"pk": saved_search.pk})
+        )
+
+        assert response.status_code == 200
+
+    def test_edit_view_requires_authentication(self, client):
+        """Test edit view redirects unauthenticated users."""
+        saved_search = SavedSearchFactory()
+
+        response = client.get(
+            reverse("searches:savedsearch-update", kwargs={"pk": saved_search.pk})
+        )
+
+        assert response.status_code == 302
+        assert "/login/" in response.url
+
+    def test_edit_view_only_shows_own_searches(self, client):
+        """Test users can only edit their own saved searches."""
+        user = UserFactory()
+        other_user = UserFactory()
+        saved_search = SavedSearchFactory(user=other_user)
+
+        client.force_login(user)
+
+        response = client.get(
+            reverse("searches:savedsearch-update", kwargs={"pk": saved_search.pk})
+        )
+
+        assert response.status_code == 404
+
+
+@pytest.mark.django_db
+class TestSavedSearchDeleteView:
+    def test_delete_view_renders(self, client):
+        """Test saved search delete confirmation page renders."""
+        user = UserFactory()
+        muni = MuniFactory()
+        saved_search = SavedSearchFactory(user=user)
+        saved_search.search.municipalities.add(muni)
+
+        client.force_login(user)
+
+        response = client.get(
+            reverse("searches:savedsearch-delete", kwargs={"pk": saved_search.pk})
+        )
+
+        assert response.status_code == 200
+
+    def test_delete_view_without_municipality(self, client):
+        """Test delete view renders even without a municipality."""
+        user = UserFactory()
+        saved_search = SavedSearchFactory(user=user)
+        # Don't add any municipalities
+
+        client.force_login(user)
+
+        response = client.get(
+            reverse("searches:savedsearch-delete", kwargs={"pk": saved_search.pk})
+        )
+
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db
+class TestSavedSearchCreateView:
+    def test_create_view_renders(self, client):
+        """Test saved search create page renders."""
+        user = UserFactory()
+        client.force_login(user)
+
+        response = client.get(reverse("searches:savedsearch-create"))
+
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary

Fixes a 500 error on `/searches/<uuid>/update/` caused by templates accessing `.muni` on Search objects when the model only has `.municipalities` (M2M field).

## Root Cause

Multiple templates were accessing `search.muni.name` and `search.muni.subdomain`, but the Search model was changed to use a ManyToMany `municipalities` field. This caused AttributeError which resulted in 500 errors.

## Fix

Added a `muni` property to the Search model that returns `self.municipalities.first()`, providing backwards compatibility with existing templates.

## Affected Templates

- `savedsearch_edit.html`
- `savedsearch_confirm_delete.html` 
- `search_update.txt` and `search_update.html` (email templates)
- `savedsearch_form.html`

## Why Sentry didn't catch it

Django template errors during rendering can sometimes be swallowed or not properly reported to Sentry depending on how the error occurs in the template engine.

## Test plan

- [x] All existing tests pass
- [ ] Manually verify `/searches/<uuid>/update/` no longer returns 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)