### PR TITLE
fix(searches): update email templates to use new_pages data

### DIFF
--- a/templates/email/search_update.html
+++ b/templates/email/search_update.html
@@ -7,7 +7,7 @@
         <meta http-equiv="x-ua-compatible" content="ie=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="x-apple-disable-message-reformatting">
-        <title>Updates from {{ subscription.search }}</title>
+        <title>New Results for {{ subscription.name }}</title>
     <!--[if mso]>
     <xml>
       <o:OfficeDocumentSettings>
@@ -131,7 +131,7 @@
     </head>
     <body style="margin:0;padding:0;width:100%;word-break:break-word;-webkit-font-smoothing:antialiased;">
 
-        <div lang="en" style="display:none;"><!-- Add your preheader text here --></div>
+        <div lang="en" style="display:none;">New results found for your saved search "{{ subscription.name }}"</div>
 
         <table lang="en" bgcolor="#EEEEEE" cellpadding="16" cellspacing="0" role="presentation" width="100%">
             <tr>
@@ -147,65 +147,45 @@
                                             <table class="full-width-sm" align="center" cellpadding="0" cellspacing="0" role="presentation" width="60%" style="margin: 0 auto;">
                                                 <tr>
                                                     <td class="px-sm-16">
-                                                        <img src="https://i.imgur.com/XqzhK67.png" width="36" alt="Download" style="max-width: 36px; width: 100%;">
-                                                        <h2>Updates from {{ subscription.search }}</h2>
-                                                        {% if subscription.search.all_results %}
-                                                            <p>Showing all updates from {{ subscription.search.muni.name }}</p>
+                                                        <img src="https://i.imgur.com/XqzhK67.png" width="36" alt="Civic Observer" style="max-width: 36px; width: 100%;">
+                                                        <h2>New Results for "{{ subscription.name }}"</h2>
+
+                                                        {% if subscription.search.search_term %}
+                                                            <p>Search term: <strong>{{ subscription.search.search_term }}</strong></p>
                                                         {% else %}
-                                                            {% if subscription.search.search_term %}
-                                                                <p>Showing results for: <strong>{{ subscription.search.search_term }}</strong></p>
-                                                            {% endif %}
+                                                            <p>Showing all new documents</p>
                                                         {% endif %}
 
-                                                        {% if subscription.search.agenda_match_json %}
-                                                            <h3>Recent agenda matches</h3>
+                                                        {% if subscription.search.muni %}
+                                                            <p>Municipality: <strong>{{ subscription.search.muni.name }}, {{ subscription.search.muni.state }}</strong></p>
+                                                        {% endif %}
+
+                                                        {% if new_pages %}
+                                                            <h3>New Results ({{ new_pages|length }})</h3>
                                                             <div>
-                                                                <ul>
-                                                                    {% for agenda in subscription.search.agenda_match_json|slice:":5" %}
-                                                                        <li><a href="https://{{ subscription.search.muni.subdomain }}.civic.band/meetings/agendas?meeting={{ agenda.meeting|urlencode }}&date={{ agenda.date|urlencode }}">
-                                                                            {{ agenda.meeting }} on {{ agenda.date }}
-                                                                            {% if agenda.text %}
-                                                                                <br><small>{{ agenda.text|truncatewords:20 }}</small>
-                                                                            {% endif %}
-                                                                        </a></li>
+                                                                <ul style="padding-left: 20px;">
+                                                                    {% for page in new_pages|slice:":10" %}
+                                                                        <li style="margin-bottom: 12px;">
+                                                                            <a href="https://{{ page.document.municipality.subdomain }}.civic.band/meetings/{% if page.document.document_type == 'agenda' %}agendas{% else %}minutes{% endif %}?meeting={{ page.document.meeting_name|urlencode }}&date={{ page.document.meeting_date|date:'Y-m-d' }}">
+                                                                                <strong>{{ page.document.meeting_name }}</strong> - {{ page.document.meeting_date|date:"M d, Y" }}
+                                                                                <br>
+                                                                                <span style="color: #666; font-size: 14px;">
+                                                                                    {% if page.document.document_type == "agenda" %}📋 Agenda{% else %}📝 Minutes{% endif %}
+                                                                                    - Page {{ page.page_number }}
+                                                                                </span>
+                                                                                {% if page.text %}
+                                                                                    <br><small style="color: #888;">{{ page.text|truncatewords:25 }}</small>
+                                                                                {% endif %}
+                                                                            </a>
+                                                                        </li>
                                                                     {% endfor %}
                                                                 </ul>
-                                                                {% if subscription.search.agenda_match_json|length > 5 %}
-                                                                    <p><em>And {{ subscription.search.agenda_match_json|length|add:"-5" }} more...</em></p>
+                                                                {% if new_pages|length > 10 %}
+                                                                    <p><em>And {{ new_pages|length|add:"-10" }} more results...</em></p>
                                                                 {% endif %}
                                                             </div>
-                                                        {% endif %}
-
-                                                        {% if subscription.search.minutes_match_json %}
-                            <!-- Divider between sections -->
-                                                            <table cellpadding="0" cellspacing="0" role="presentation" width="100%">
-                                                                <tr>
-                                                                    <td class="divider" style="padding: 24px 16px;">
-                                                                        <div style="background: #EEEEEE; height: 1px; line-height: 1px;">‌</div>
-                                                                    </td>
-                                                                </tr>
-                                                            </table>
-
-                                                            <h3>Recent minutes matches</h3>
-                                                            <div>
-                                                                <ul>
-                                                                    {% for minutes in subscription.search.minutes_match_json|slice:":5" %}
-                                                                        <li><a href="https://{{ subscription.search.muni.subdomain }}.civic.band/meetings/minutes?meeting={{ minutes.meeting|urlencode }}&date={{ minutes.date|urlencode }}">
-                                                                            {{ minutes.meeting }} on {{ minutes.date }}
-                                                                            {% if minutes.text %}
-                                                                                <br><small>{{ minutes.text|truncatewords:20 }}</small>
-                                                                            {% endif %}
-                                                                        </a></li>
-                                                                    {% endfor %}
-                                                                </ul>
-                                                                {% if subscription.search.minutes_match_json|length > 5 %}
-                                                                    <p><em>And {{ subscription.search.minutes_match_json|length|add:"-5" }} more...</em></p>
-                                                                {% endif %}
-                                                            </div>
-                                                        {% endif %}
-
-                                                        {% if not subscription.search.agenda_match_json and not subscription.search.minutes_match_json %}
-                                                            <p><em>No new matches found. We'll notify you when new results are available.</em></p>
+                                                        {% else %}
+                                                            <p><em>No new results were found. We'll notify you when new results are available.</em></p>
                                                         {% endif %}
                                                     </td>
                                                 </tr>
@@ -216,7 +196,9 @@
                                 <table cellpadding="0" cellspacing="0" role="presentation" width="100%" style="border: 2px solid #0099E5;">
                                     <tr>
                                         <td style="color: #0099E5; padding: 16px 32px;">
-                                            You're receiving this because you signed up to receive updates from <a href="https://civic.band">CivicBand</a> sites via <a href="https://civic.observer">CivicObserver</a>.
+                                            You're receiving this because you signed up for notifications from <a href="https://civic.observer">Civic Observer</a>.
+                                            <br>
+                                            <a href="https://civic.observer/searches/">Manage your saved searches</a>
                                         </td>
                                     </tr>
                                 </table>

--- a/templates/email/search_update.txt
+++ b/templates/email/search_update.txt
@@ -2,46 +2,24 @@ Hello,
 
 We found new results for your saved search "{{ subscription.name }}".
 
-Search: {{ subscription.search }}
-Municipality: {{ subscription.search.muni.name }}
-{% if subscription.search.all_results %}
-Showing all updates from {{ subscription.search.muni.name }}
-{% else %}{% if subscription.search.search_term %}
-Search term: {{ subscription.search.search_term }}
-{% endif %}{% endif %}
+{% if subscription.search.search_term %}Search term: {{ subscription.search.search_term }}{% else %}Showing all new documents{% endif %}
+{% if subscription.search.muni %}Municipality: {{ subscription.search.muni.name }}, {{ subscription.search.muni.state }}{% endif %}
 
-{% if subscription.search.agenda_match_json %}
-RECENT AGENDA MATCHES:
-{% for agenda in subscription.search.agenda_match_json|slice:":10" %}
-- {{ agenda.meeting }} on {{ agenda.date }}
-  View: https://{{ subscription.search.muni.subdomain }}.civic.band/meetings/agendas?meeting={{ agenda.meeting|urlencode }}&date={{ agenda.date|urlencode }}
+{% if new_pages %}NEW RESULTS ({{ new_pages|length }}):
+{% for page in new_pages|slice:":10" %}
+- {{ page.document.meeting_name }} - {{ page.document.meeting_date|date:"M d, Y" }}
+  {% if page.document.document_type == "agenda" %}Agenda{% else %}Minutes{% endif %} - Page {{ page.page_number }}
+  View: https://{{ page.document.municipality.subdomain }}.civic.band/meetings/{% if page.document.document_type == "agenda" %}agendas{% else %}minutes{% endif %}?meeting={{ page.document.meeting_name|urlencode }}&date={{ page.document.meeting_date|date:"Y-m-d" }}
 {% endfor %}
-{% if subscription.search.agenda_match_json|length > 10 %}
-... and {{ subscription.search.agenda_match_json|length|add:"-10" }} more
+{% if new_pages|length > 10 %}
+... and {{ new_pages|length|add:"-10" }} more results
 {% endif %}
+{% else %}No new results were found. We'll notify you when new results are available.
 {% endif %}
-
-{% if subscription.search.minutes_match_json %}
-RECENT MINUTES MATCHES:
-{% for minutes in subscription.search.minutes_match_json|slice:":10" %}
-- {{ minutes.meeting }} on {{ minutes.date }}
-  View: https://{{ subscription.search.muni.subdomain }}.civic.band/meetings/minutes?meeting={{ minutes.meeting|urlencode }}&date={{ minutes.date|urlencode }}
-{% endfor %}
-{% if subscription.search.minutes_match_json|length > 10 %}
-... and {{ subscription.search.minutes_match_json|length|add:"-10" }} more
-{% endif %}
-{% endif %}
-
-{% if not subscription.search.agenda_match_json and not subscription.search.minutes_match_json %}
-No new matches found. We'll notify you when new results are available.
-{% endif %}
-
-To view all results on CivicBand:
-https://{{ subscription.search.muni.subdomain }}.civic.band/meetings/
 
 Best regards,
 The Civic Observer Team
 
 --
-You're receiving this because you signed up to receive updates from CivicBand sites via CivicObserver.
+You're receiving this because you signed up for notifications from Civic Observer.
 To manage your saved searches, visit: https://civic.observer/searches/

--- a/templates/searches/partials/notification_settings.html
+++ b/templates/searches/partials/notification_settings.html
@@ -78,16 +78,39 @@
         </div>
     {% endif %}
 
-    {# Last Checked #}
-    {% if saved_search.last_checked %}
+    {# Last Checked for New Pages (from Search model) #}
+    {% if saved_search.search.last_checked_for_new_pages %}
         <div>
-            <dt class="text-sm font-medium text-gray-600">Last Checked</dt>
+            <dt class="text-sm font-medium text-gray-600">Last Checked for Updates</dt>
             <dd class="mt-1 text-sm text-gray-900">
                 <div class="flex items-center">
                     <svg class="w-4 h-4 mr-2 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"></path>
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"></path>
                     </svg>
-                    {{ saved_search.last_checked|date:"M d, Y g:i A" }}
+                    {{ saved_search.search.last_checked_for_new_pages|date:"M d, Y g:i A" }}
+                </div>
+                <p class="mt-1 text-xs text-gray-500">Last time we checked for new documents from CivicBand</p>
+            </dd>
+        </div>
+    {% else %}
+        <div>
+            <dt class="text-sm font-medium text-gray-600">Last Checked for Updates</dt>
+            <dd class="mt-1 text-sm text-gray-500 italic">
+                Not yet checked
+            </dd>
+        </div>
+    {% endif %}
+
+    {# Current Result Count #}
+    {% if saved_search.search.last_result_count %}
+        <div>
+            <dt class="text-sm font-medium text-gray-600">Current Results</dt>
+            <dd class="mt-1 text-sm text-gray-900">
+                <div class="flex items-center">
+                    <svg class="w-4 h-4 mr-2 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+                    </svg>
+                    {{ saved_search.search.last_result_count }} matching page{{ saved_search.search.last_result_count|pluralize }}
                 </div>
             </dd>
         </div>


### PR DESCRIPTION
## Summary

- Fixes notification emails that were always showing "No new matches found" even when there were actual search results
- The email templates were using legacy fields (`agenda_match_json`, `minutes_match_json`) that no longer exist on the Search model
- Updated templates to use the `new_pages` QuerySet that is correctly passed in the template context
- Added "Last Checked for Updates" timestamp display to saved search detail page so users can see when their search was last checked

## Changes

- **templates/email/search_update.html** - Rewritten to iterate over `new_pages` QuerySet instead of legacy fields
- **templates/email/search_update.txt** - Plain text version also updated to use `new_pages`
- **templates/searches/partials/notification_settings.html** - Added display for `last_checked_for_new_pages` timestamp and result count
- **tests/searches/test_models.py** - Added 2 new tests for email template rendering with and without results

## Test plan

- [x] All 370 existing tests pass
- [x] New tests verify email template renders `new_pages` correctly
- [x] New tests verify "no new results" message appears for empty QuerySet

🤖 Generated with [Claude Code](https://claude.com/claude-code)