### PR TITLE
feat(users): add admin view to invite users by email

### DIFF
--- a/templates/admin/users/invite_user.html
+++ b/templates/admin/users/invite_user.html
@@ -1,0 +1,52 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block title %}{{ title }} | {{ site_title }}{% endblock %}
+
+{% block breadcrumbs %}
+    <div class="breadcrumbs">
+        <a href="{% url 'admin:index' %}">{% translate "Home" %}</a>
+        &rsaquo; {{ title }}
+    </div>
+{% endblock breadcrumbs %}
+
+{% block content %}
+    <h1>{{ title }}</h1>
+
+    <p>Send a login invitation email to a new user. They will be able to create their account by clicking the link in the email.</p>
+
+    {% if messages %}
+        <ul class="messagelist">
+            {% for message in messages %}
+                <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+            {% endfor %}
+        </ul>
+    {% endif %}
+
+    <form method="post">
+        {% csrf_token %}
+        <fieldset class="module aligned">
+            {% for field in form %}
+                <div class="form-row">
+                    <div>
+                        {{ field.label_tag }}
+                        {{ field }}
+                        {% if field.help_text %}
+                            <p class="help">{{ field.help_text }}</p>
+                        {% endif %}
+                        {% if field.errors %}
+                            <ul class="errorlist">
+                                {% for error in field.errors %}
+                                    <li>{{ error }}</li>
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
+                    </div>
+                </div>
+            {% endfor %}
+        </fieldset>
+        <div class="submit-row">
+            <input type="submit" value="{% translate 'Send Invitation' %}" class="default">
+        </div>
+    </form>
+{% endblock content %}

--- a/users/admin.py
+++ b/users/admin.py
@@ -1,7 +1,63 @@
-from django.contrib import admin
+from django import forms
+from django.contrib import admin, messages
+from django.contrib.admin.views.decorators import staff_member_required
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+from django.shortcuts import redirect, render
+from django.urls import path
+from stagedoor.helpers import email_login_link
+from stagedoor.models import generate_token
 
 from .models import User
+
+
+class InviteUserForm(forms.Form):
+    """Simple form for inviting a user by email."""
+
+    email = forms.EmailField(
+        label="Email address",
+        help_text="Enter the email address of the user you want to invite.",
+    )
+
+
+@staff_member_required
+def invite_user_view(request):
+    """Admin view to invite a new user by sending them a login email."""
+    if request.method == "POST":
+        form = InviteUserForm(request.POST)
+        if form.is_valid():
+            email = form.cleaned_data["email"]
+            token = generate_token(email=email)
+            if token:
+                email_login_link(request, token)
+                messages.success(request, f"Invitation sent to {email}")
+                return redirect("admin:invite_user")
+            else:
+                messages.error(request, f"Could not generate invite for {email}")
+    else:
+        form = InviteUserForm()
+
+    context = {
+        "form": form,
+        "title": "Invite User",
+        "site_header": admin.site.site_header,
+        "site_title": admin.site.site_title,
+        "has_permission": True,
+    }
+    return render(request, "admin/users/invite_user.html", context)
+
+
+# Register the custom admin URL by wrapping get_urls
+_original_get_urls = admin.site.get_urls
+
+
+def _get_urls_with_invite():
+    custom_urls = [
+        path("invite/", invite_user_view, name="invite_user"),
+    ]
+    return custom_urls + _original_get_urls()
+
+
+admin.site.get_urls = _get_urls_with_invite  # type: ignore[method-assign]
 
 
 @admin.register(User)


### PR DESCRIPTION
## Summary

- Adds a custom admin view at `/admin/invite/` that lets administrators invite new users by email
- Uses stagedoor's existing magic-link authentication to send login emails
- When the recipient clicks the link, their account is created and they are logged in

## Changes

- **users/admin.py** - Added `InviteUserForm` and `invite_user_view` function, registered as custom admin URL
- **templates/admin/users/invite_user.html** - Admin-styled form template
- **users/tests.py** - Added 5 tests for the invite functionality

## Usage

1. Navigate to `/admin/invite/` (must be logged in as staff)
2. Enter an email address
3. Click "Send Invitation"
4. User receives stagedoor magic-link email
5. User clicks link, account is created, user is logged in

## Test plan

- [x] All existing tests pass
- [x] Test that non-staff users cannot access the invite view
- [x] Test that staff users can access the view
- [x] Test that the form renders correctly
- [x] Test that submitting a valid email sends an invitation
- [x] Test that invalid emails show validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)