### PR TITLE
feat: add UTM tracking for civic ecosystem outbound links

### DIFF
--- a/analytics/templatetags/utm.py
+++ b/analytics/templatetags/utm.py
@@ -1,0 +1,70 @@
+"""Template tag for adding UTM parameters to civic ecosystem URLs."""
+
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+from django import template
+
+register = template.Library()
+
+# Domains that should receive UTM parameters
+CIVIC_DOMAINS = [
+    "civic.band",
+    "docs.civic.band",
+]
+
+
+def is_civic_domain(hostname: str) -> bool:
+    """Check if hostname belongs to civic ecosystem."""
+    if not hostname:
+        return False
+    for domain in CIVIC_DOMAINS:
+        if hostname == domain or hostname.endswith(f".{domain}"):
+            return True
+    return False
+
+
+@register.simple_tag
+def civic_url(
+    url: str,
+    medium: str,
+    campaign: str,
+    content: str = "link",
+) -> str:
+    """
+    Add UTM parameters to a civic ecosystem URL.
+
+    Usage:
+        {% load utm %}
+        {% civic_url page_url medium='search' campaign='search_results' content='view_button' %}
+
+    Returns the URL unchanged if it's not a civic ecosystem domain.
+    """
+    if not url:
+        return ""
+
+    try:
+        parsed = urlparse(url)
+    except (ValueError, AttributeError):
+        return url
+
+    # Only add UTM params to civic ecosystem domains
+    if not is_civic_domain(parsed.netloc):
+        return url
+
+    # Parse existing query parameters
+    query_params = parse_qs(parsed.query, keep_blank_values=True)
+
+    # Add/overwrite UTM parameters
+    utm_params = {
+        "utm_source": ["civicobserver"],
+        "utm_medium": [medium],
+        "utm_campaign": [campaign],
+        "utm_content": [content],
+    }
+    query_params.update(utm_params)
+
+    # Rebuild the URL
+    new_query = urlencode(query_params, doseq=True)
+    new_parsed = parsed._replace(query=new_query)
+
+    return urlunparse(new_parsed)

--- a/config/urls.py
+++ b/config/urls.py
@@ -26,6 +26,7 @@ from . import views
 urlpatterns: list[URLPattern | URLResolver] = [
     path("", views.homepage, name="homepage"),
     path("admin/", admin.site.urls),
+    path("api/", views.api_page, name="api_page"),
     path("api-keys/", include("apikeys.urls")),
     path("api/v1/", include((apikeys_internal, "apikeys_internal"))),
     path("auth/", include("stagedoor.urls", namespace="stagedoor")),

--- a/config/views.py
+++ b/config/views.py
@@ -18,3 +18,8 @@ def health_check(request):
     status = db_ok
     status_code = 200 if status else 503
     return JsonResponse({"status": "ok" if status else "unhealthy"}, status=status_code)
+
+
+def api_page(request):
+    """API information page for researchers and developers."""
+    return render(request, "api.html")

--- a/docs/plans/2025-12-04-marketing-refresh.md
+++ b/docs/plans/2025-12-04-marketing-refresh.md
@@ -1,0 +1,1005 @@
+# Marketing Refresh Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Refresh the landing page with interactive feature demos using hardcoded JSON data, and add a new /api page for researchers and journalists.
+
+**Architecture:** Replace the current landing page with a hero section followed by alternating feature blocks, each with a live interactive preview. Use hardcoded JSON data in templates for client-side interactivity (Alpine.js) to avoid DB queries from bot traffic. Add a new /api page with layered content (mission → use cases → technical → docs link).
+
+**Tech Stack:** Django templates, Alpine.js for interactivity, Tailwind CSS, hardcoded JSON data
+
+---
+
+## Task 1: Update Landing Page Hero Section
+
+**Files:**
+- Modify: `templates/homepage.html`
+
+**Step 1: Update the hero section**
+
+Replace the current hero with a cleaner design that has the main value proposition and tiered CTAs:
+
+```html
+{% extends "base.html" %}
+{% load static %}
+
+{% block title %}{{ title }} - Civic Transparency Platform{% endblock %}
+
+{% block content %}
+<!-- Hero Section -->
+<div class="relative overflow-hidden bg-gradient-to-br from-indigo-50 to-white">
+    <div class="absolute inset-0 overflow-hidden" aria-hidden="true">
+        <div class="absolute -top-40 -right-40 w-80 h-80 bg-indigo-100 rounded-full opacity-50 blur-3xl"></div>
+        <div class="absolute -bottom-40 -left-40 w-80 h-80 bg-indigo-100 rounded-full opacity-50 blur-3xl"></div>
+    </div>
+
+    <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24 sm:py-32">
+        <div class="text-center max-w-3xl mx-auto">
+            <h1 class="text-4xl sm:text-5xl lg:text-6xl font-extrabold text-gray-900 tracking-tight">
+                Stay informed about<br>
+                <span class="text-indigo-600">local government</span>
+            </h1>
+            <p class="mt-6 text-xl text-gray-600 max-w-2xl mx-auto">
+                Search meeting agendas and minutes, save important pages, and get notified when topics you care about come up in your community.
+            </p>
+            <div class="mt-10 flex flex-col sm:flex-row gap-4 justify-center">
+                <a href="{% url 'stagedoor:auth' %}" class="inline-flex items-center justify-center px-8 py-4 border border-transparent text-lg font-medium rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 shadow-lg hover:shadow-xl transition-all duration-200">
+                    Get Started Free
+                    <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
+                    </svg>
+                </a>
+                <a href="#features" class="inline-flex items-center justify-center px-8 py-4 border border-gray-300 text-lg font-medium rounded-lg text-gray-700 bg-white hover:bg-gray-50 shadow hover:shadow-md transition-all duration-200">
+                    See how it works
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+```
+
+**Step 2: Verify the template renders**
+
+Run the dev server and check http://localhost:8000/
+
+**Step 3: Commit**
+
+```bash
+git add templates/homepage.html
+git commit -m "feat(marketing): update hero section with cleaner design and tiered CTAs"
+```
+
+---
+
+## Task 2: Add Search Feature Block with Demo
+
+**Files:**
+- Modify: `templates/homepage.html`
+
+**Step 1: Add the search feature block after the hero**
+
+Add an alternating feature block with a hardcoded search demo:
+
+```html
+<!-- Feature 1: Search -->
+<div id="features" class="py-24 bg-white">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="lg:grid lg:grid-cols-2 lg:gap-16 items-center">
+            <!-- Text Content -->
+            <div>
+                <div class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-indigo-100 text-indigo-800 mb-4">
+                    <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+                    </svg>
+                    Search
+                </div>
+                <h2 class="text-3xl font-bold text-gray-900 sm:text-4xl">
+                    Find what matters in meeting documents
+                </h2>
+                <p class="mt-4 text-lg text-gray-600">
+                    Search across thousands of meeting agendas and minutes from municipalities across the country. Use powerful filters to narrow down by date, location, or document type.
+                </p>
+                <div class="mt-8">
+                    <a href="{% url 'meetings:meeting-search' %}" class="inline-flex items-center text-indigo-600 font-medium hover:text-indigo-700">
+                        Try searching now
+                        <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
+                        </svg>
+                    </a>
+                </div>
+            </div>
+
+            <!-- Interactive Demo -->
+            <div class="mt-12 lg:mt-0" x-data="searchDemo()">
+                <div class="bg-gray-50 rounded-2xl p-6 shadow-lg border border-gray-200">
+                    <div class="flex items-center gap-3 mb-4">
+                        <div class="flex-1">
+                            <input type="text"
+                                   x-model="query"
+                                   @input="filterResults()"
+                                   placeholder="Try searching: budget, housing, zoning..."
+                                   class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
+                        </div>
+                    </div>
+
+                    <div class="space-y-3 max-h-64 overflow-y-auto">
+                        <template x-for="result in filteredResults" :key="result.id">
+                            <div class="bg-white p-4 rounded-lg border border-gray-200 hover:border-indigo-300 transition-colors">
+                                <div class="flex items-start justify-between">
+                                    <div class="flex-1 min-w-0">
+                                        <p class="text-sm font-medium text-gray-900" x-text="result.title"></p>
+                                        <p class="text-xs text-gray-500 mt-1">
+                                            <span x-text="result.municipality"></span> • <span x-text="result.date"></span>
+                                        </p>
+                                        <p class="text-sm text-gray-600 mt-2 line-clamp-2" x-text="result.snippet"></p>
+                                    </div>
+                                    <span class="ml-3 inline-flex items-center px-2 py-1 rounded text-xs font-medium"
+                                          :class="result.type === 'agenda' ? 'bg-blue-100 text-blue-800' : 'bg-green-100 text-green-800'"
+                                          x-text="result.type"></span>
+                                </div>
+                            </div>
+                        </template>
+                        <div x-show="filteredResults.length === 0" class="text-center py-8 text-gray-500">
+                            <p>No results found. Try a different search term.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+```
+
+**Step 2: Add the Alpine.js searchDemo component at the bottom of the template**
+
+```html
+<script>
+function searchDemo() {
+    return {
+        query: '',
+        results: [
+            {
+                id: 1,
+                title: 'City Council Regular Meeting - Budget Discussion',
+                municipality: 'Berkeley, CA',
+                date: 'Nov 15, 2024',
+                type: 'agenda',
+                snippet: 'Discussion of FY2025 budget allocations including housing assistance programs and infrastructure improvements...'
+            },
+            {
+                id: 2,
+                title: 'Planning Commission - Zoning Amendment Review',
+                municipality: 'Oakland, CA',
+                date: 'Nov 12, 2024',
+                type: 'minutes',
+                snippet: 'Review of proposed zoning changes for mixed-use development in the downtown corridor...'
+            },
+            {
+                id: 3,
+                title: 'Housing Authority Board Meeting',
+                municipality: 'San Francisco, CA',
+                date: 'Nov 10, 2024',
+                type: 'agenda',
+                snippet: 'Approval of affordable housing initiatives and tenant assistance program updates...'
+            },
+            {
+                id: 4,
+                title: 'Budget Committee - Q3 Financial Review',
+                municipality: 'Alameda, CA',
+                date: 'Nov 8, 2024',
+                type: 'minutes',
+                snippet: 'Review of third quarter expenditures and revenue projections for municipal services...'
+            },
+            {
+                id: 5,
+                title: 'City Council - Housing Policy Update',
+                municipality: 'Fremont, CA',
+                date: 'Nov 5, 2024',
+                type: 'agenda',
+                snippet: 'First reading of updated housing policy including density bonus provisions...'
+            }
+        ],
+        filteredResults: [],
+
+        init() {
+            this.filteredResults = this.results;
+        },
+
+        filterResults() {
+            if (!this.query.trim()) {
+                this.filteredResults = this.results;
+                return;
+            }
+            const q = this.query.toLowerCase();
+            this.filteredResults = this.results.filter(r =>
+                r.title.toLowerCase().includes(q) ||
+                r.snippet.toLowerCase().includes(q) ||
+                r.municipality.toLowerCase().includes(q)
+            );
+        }
+    };
+}
+</script>
+```
+
+**Step 3: Verify the search demo works**
+
+Run the dev server and test the interactive search on the homepage.
+
+**Step 4: Commit**
+
+```bash
+git add templates/homepage.html
+git commit -m "feat(marketing): add interactive search demo feature block"
+```
+
+---
+
+## Task 3: Add Notebook Feature Block with Demo
+
+**Files:**
+- Modify: `templates/homepage.html`
+
+**Step 1: Add the notebook feature block (right-aligned text, left demo)**
+
+```html
+<!-- Feature 2: Notebooks -->
+<div class="py-24 bg-gray-50">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="lg:grid lg:grid-cols-2 lg:gap-16 items-center">
+            <!-- Interactive Demo (Left side) -->
+            <div class="order-2 lg:order-1 mt-12 lg:mt-0" x-data="notebookDemo()">
+                <div class="bg-white rounded-2xl p-6 shadow-lg border border-gray-200">
+                    <div class="flex items-center justify-between mb-4">
+                        <h3 class="font-semibold text-gray-900">My Research Notebook</h3>
+                        <span class="text-sm text-gray-500" x-text="savedPages.length + ' pages'"></span>
+                    </div>
+
+                    <div class="space-y-3 max-h-64 overflow-y-auto">
+                        <template x-for="page in savedPages" :key="page.id">
+                            <div class="p-4 rounded-lg border border-gray-200 hover:border-indigo-300 transition-colors">
+                                <div class="flex items-start justify-between">
+                                    <div class="flex-1 min-w-0">
+                                        <p class="text-sm font-medium text-gray-900" x-text="page.title"></p>
+                                        <p class="text-xs text-gray-500 mt-1" x-text="page.source"></p>
+                                    </div>
+                                    <button @click="removePage(page.id)"
+                                            class="ml-2 text-gray-400 hover:text-red-500 transition-colors">
+                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                                        </svg>
+                                    </button>
+                                </div>
+                                <div class="mt-2 flex flex-wrap gap-1">
+                                    <template x-for="tag in page.tags" :key="tag">
+                                        <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-700" x-text="tag"></span>
+                                    </template>
+                                </div>
+                            </div>
+                        </template>
+                    </div>
+
+                    <div class="mt-4 pt-4 border-t border-gray-200">
+                        <button @click="addSamplePage()"
+                                class="w-full inline-flex items-center justify-center px-4 py-2 border border-dashed border-gray-300 rounded-lg text-sm text-gray-600 hover:border-indigo-500 hover:text-indigo-600 transition-colors">
+                            <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+                            </svg>
+                            Save another page
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Text Content (Right side) -->
+            <div class="order-1 lg:order-2">
+                <div class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-indigo-100 text-indigo-800 mb-4">
+                    <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
+                    </svg>
+                    Notebooks
+                </div>
+                <h2 class="text-3xl font-bold text-gray-900 sm:text-4xl">
+                    Save and organize your research
+                </h2>
+                <p class="mt-4 text-lg text-gray-600">
+                    Clip important pages from meeting documents directly to your notebooks. Tag them, organize them, and access them anytime. Perfect for journalists, researchers, and engaged citizens.
+                </p>
+                <div class="mt-8">
+                    <a href="{% url 'notebooks:notebook-list' %}" class="inline-flex items-center text-indigo-600 font-medium hover:text-indigo-700">
+                        Create your first notebook
+                        <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
+                        </svg>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+```
+
+**Step 2: Add the notebookDemo Alpine component**
+
+```javascript
+function notebookDemo() {
+    return {
+        savedPages: [
+            {
+                id: 1,
+                title: 'Budget Discussion - FY2025 Allocations',
+                source: 'Berkeley City Council • Nov 15, 2024',
+                tags: ['budget', 'housing']
+            },
+            {
+                id: 2,
+                title: 'Zoning Amendment Review',
+                source: 'Oakland Planning Commission • Nov 12, 2024',
+                tags: ['zoning', 'development']
+            },
+            {
+                id: 3,
+                title: 'Affordable Housing Initiatives',
+                source: 'SF Housing Authority • Nov 10, 2024',
+                tags: ['housing', 'affordable']
+            }
+        ],
+        nextId: 4,
+        samplePages: [
+            { title: 'Transit Funding Discussion', source: 'BART Board • Nov 1, 2024', tags: ['transit', 'budget'] },
+            { title: 'Environmental Impact Review', source: 'County Planning • Oct 28, 2024', tags: ['environment'] },
+            { title: 'Public Safety Committee Report', source: 'City Council • Oct 25, 2024', tags: ['safety'] }
+        ],
+
+        removePage(id) {
+            this.savedPages = this.savedPages.filter(p => p.id !== id);
+        },
+
+        addSamplePage() {
+            if (this.samplePages.length === 0) return;
+            const page = this.samplePages.shift();
+            this.savedPages.push({
+                id: this.nextId++,
+                ...page
+            });
+        }
+    };
+}
+```
+
+**Step 3: Verify the notebook demo works**
+
+Test adding/removing pages in the demo.
+
+**Step 4: Commit**
+
+```bash
+git add templates/homepage.html
+git commit -m "feat(marketing): add interactive notebook demo feature block"
+```
+
+---
+
+## Task 4: Add Saved Search Feature Block with Demo
+
+**Files:**
+- Modify: `templates/homepage.html`
+
+**Step 1: Add the saved search feature block (left text, right demo)**
+
+```html
+<!-- Feature 3: Saved Searches -->
+<div class="py-24 bg-white">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="lg:grid lg:grid-cols-2 lg:gap-16 items-center">
+            <!-- Text Content -->
+            <div>
+                <div class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-indigo-100 text-indigo-800 mb-4">
+                    <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"></path>
+                    </svg>
+                    Saved Searches
+                </div>
+                <h2 class="text-3xl font-bold text-gray-900 sm:text-4xl">
+                    Never miss an important topic
+                </h2>
+                <p class="mt-4 text-lg text-gray-600">
+                    Save your search criteria and we'll monitor new meeting documents for you. Get notified the moment something relevant is published.
+                </p>
+                <div class="mt-8">
+                    <a href="{% url 'searches:savedsearch-list' %}" class="inline-flex items-center text-indigo-600 font-medium hover:text-indigo-700">
+                        Set up your first saved search
+                        <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
+                        </svg>
+                    </a>
+                </div>
+            </div>
+
+            <!-- Interactive Demo -->
+            <div class="mt-12 lg:mt-0" x-data="savedSearchDemo()">
+                <div class="bg-gray-50 rounded-2xl p-6 shadow-lg border border-gray-200">
+                    <h3 class="font-semibold text-gray-900 mb-4">Your Saved Searches</h3>
+
+                    <div class="space-y-3">
+                        <template x-for="search in searches" :key="search.id">
+                            <div class="bg-white p-4 rounded-lg border border-gray-200">
+                                <div class="flex items-center justify-between">
+                                    <div>
+                                        <p class="font-medium text-gray-900" x-text="search.name"></p>
+                                        <p class="text-sm text-gray-500 mt-1">
+                                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-indigo-100 text-indigo-800" x-text="'\"' + search.term + '\"'"></span>
+                                            <span class="ml-2" x-text="search.scope"></span>
+                                        </p>
+                                    </div>
+                                    <div class="flex items-center gap-2">
+                                        <span x-show="search.newResults > 0"
+                                              class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
+                                            <span x-text="search.newResults"></span> new
+                                        </span>
+                                        <span class="inline-flex items-center px-2 py-1 rounded text-xs font-medium"
+                                              :class="search.frequency === 'immediate' ? 'bg-red-100 text-red-800' : search.frequency === 'daily' ? 'bg-blue-100 text-blue-800' : 'bg-green-100 text-green-800'"
+                                              x-text="search.frequency"></span>
+                                    </div>
+                                </div>
+                            </div>
+                        </template>
+                    </div>
+
+                    <div class="mt-4 p-4 bg-indigo-50 rounded-lg border border-indigo-100">
+                        <div class="flex items-start">
+                            <svg class="w-5 h-5 text-indigo-600 mt-0.5 mr-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                            </svg>
+                            <p class="text-sm text-indigo-800">
+                                <strong>Tip:</strong> Use "immediate" for time-sensitive topics and "weekly" for general monitoring.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+```
+
+**Step 2: Add the savedSearchDemo Alpine component**
+
+```javascript
+function savedSearchDemo() {
+    return {
+        searches: [
+            {
+                id: 1,
+                name: 'Housing Policy Updates',
+                term: 'affordable housing',
+                scope: '3 municipalities',
+                frequency: 'immediate',
+                newResults: 2
+            },
+            {
+                id: 2,
+                name: 'Budget Discussions',
+                term: 'budget',
+                scope: 'All Bay Area',
+                frequency: 'daily',
+                newResults: 5
+            },
+            {
+                id: 3,
+                name: 'Zoning Changes',
+                term: 'zoning amendment',
+                scope: 'Oakland, CA',
+                frequency: 'weekly',
+                newResults: 0
+            }
+        ]
+    };
+}
+```
+
+**Step 3: Verify the saved search demo displays correctly**
+
+Check that the frequency badges and new result indicators work.
+
+**Step 4: Commit**
+
+```bash
+git add templates/homepage.html
+git commit -m "feat(marketing): add saved search demo feature block"
+```
+
+---
+
+## Task 5: Add Static Notifications Feature Block
+
+**Files:**
+- Modify: `templates/homepage.html`
+
+**Step 1: Add the notifications feature block (right text, left static preview)**
+
+```html
+<!-- Feature 4: Notifications (Static) -->
+<div class="py-24 bg-gray-50">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="lg:grid lg:grid-cols-2 lg:gap-16 items-center">
+            <!-- Static Preview (Left side) -->
+            <div class="order-2 lg:order-1 mt-12 lg:mt-0">
+                <div class="bg-white rounded-2xl p-6 shadow-lg border border-gray-200">
+                    <h3 class="font-semibold text-gray-900 mb-4">Notification Channels</h3>
+
+                    <div class="space-y-4">
+                        <!-- Email Channel -->
+                        <div class="flex items-center justify-between p-4 rounded-lg border border-gray-200">
+                            <div class="flex items-center">
+                                <div class="w-10 h-10 rounded-full bg-blue-100 flex items-center justify-center mr-4">
+                                    <svg class="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+                                    </svg>
+                                </div>
+                                <div>
+                                    <p class="font-medium text-gray-900">Email</p>
+                                    <p class="text-sm text-gray-500">researcher@example.com</p>
+                                </div>
+                            </div>
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Active</span>
+                        </div>
+
+                        <!-- Bluesky Channel -->
+                        <div class="flex items-center justify-between p-4 rounded-lg border border-gray-200">
+                            <div class="flex items-center">
+                                <div class="w-10 h-10 rounded-full bg-sky-100 flex items-center justify-center mr-4">
+                                    <svg class="w-5 h-5 text-sky-600" viewBox="0 0 24 24" fill="currentColor">
+                                        <path d="M12 2C6.477 2 2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.879V14.89h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.989C18.343 21.129 22 16.99 22 12c0-5.523-4.477-10-10-10z"/>
+                                    </svg>
+                                </div>
+                                <div>
+                                    <p class="font-medium text-gray-900">Bluesky</p>
+                                    <p class="text-sm text-gray-500">@researcher.bsky.social</p>
+                                </div>
+                            </div>
+                            <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Active</span>
+                        </div>
+
+                        <!-- Webhook Channel -->
+                        <div class="flex items-center justify-between p-4 rounded-lg border border-dashed border-gray-300 bg-gray-50">
+                            <div class="flex items-center">
+                                <div class="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center mr-4">
+                                    <svg class="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"></path>
+                                    </svg>
+                                </div>
+                                <div>
+                                    <p class="font-medium text-gray-500">Webhook</p>
+                                    <p class="text-sm text-gray-400">For developers & integrations</p>
+                                </div>
+                            </div>
+                            <span class="text-sm text-gray-500">Coming soon</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Text Content (Right side) -->
+            <div class="order-1 lg:order-2">
+                <div class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-indigo-100 text-indigo-800 mb-4">
+                    <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"></path>
+                    </svg>
+                    Notifications
+                </div>
+                <h2 class="text-3xl font-bold text-gray-900 sm:text-4xl">
+                    Get alerted your way
+                </h2>
+                <p class="mt-4 text-lg text-gray-600">
+                    Choose how you want to receive updates. Get instant email notifications, post to Bluesky, or integrate with your own systems via webhooks.
+                </p>
+                <div class="mt-8">
+                    <a href="{% url 'notifications:channel-list' %}" class="inline-flex items-center text-indigo-600 font-medium hover:text-indigo-700">
+                        Configure your notifications
+                        <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
+                        </svg>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+```
+
+**Step 2: Commit**
+
+```bash
+git add templates/homepage.html
+git commit -m "feat(marketing): add static notifications feature block"
+```
+
+---
+
+## Task 6: Add Final CTA Section and Update Footer Link
+
+**Files:**
+- Modify: `templates/homepage.html`
+
+**Step 1: Add the final CTA section before endblock**
+
+```html
+<!-- Final CTA -->
+<div class="bg-indigo-600">
+    <div class="max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:py-24 lg:px-8 lg:flex lg:items-center lg:justify-between">
+        <div>
+            <h2 class="text-3xl font-extrabold tracking-tight text-white sm:text-4xl">
+                Ready to stay informed?
+            </h2>
+            <p class="mt-4 text-lg text-indigo-100 max-w-xl">
+                Join researchers, journalists, and engaged citizens who use CivicObserver to track local government.
+            </p>
+        </div>
+        <div class="mt-8 flex flex-col sm:flex-row gap-4 lg:mt-0 lg:flex-shrink-0">
+            <a href="{% url 'stagedoor:auth' %}" class="inline-flex items-center justify-center px-6 py-4 border border-transparent text-lg font-medium rounded-lg text-indigo-600 bg-white hover:bg-indigo-50 shadow-lg transition-all duration-200">
+                Get Started Free
+            </a>
+            <a href="{% url 'meetings:meeting-search' %}" class="inline-flex items-center justify-center px-6 py-4 border-2 border-white text-lg font-medium rounded-lg text-white hover:bg-indigo-500 transition-all duration-200">
+                Try Search First
+            </a>
+        </div>
+    </div>
+</div>
+
+{% endblock content %}
+```
+
+**Step 2: Remove the old features section and CTA from homepage.html**
+
+Delete the old `#features` section (icon grid) and old CTA section.
+
+**Step 3: Verify the complete landing page**
+
+Check that all sections flow correctly and demos work.
+
+**Step 4: Commit**
+
+```bash
+git add templates/homepage.html
+git commit -m "feat(marketing): add final CTA section and complete landing page refresh"
+```
+
+---
+
+## Task 7: Create API Page View and URL
+
+**Files:**
+- Modify: `config/views.py`
+- Modify: `config/urls.py`
+
+**Step 1: Add the api_page view to config/views.py**
+
+```python
+def api_page(request):
+    """API information page for researchers and developers."""
+    return render(request, "api.html")
+```
+
+**Step 2: Add the URL pattern to config/urls.py**
+
+Add to urlpatterns:
+```python
+path("api/", views.api_page, name="api_page"),
+```
+
+**Step 3: Commit**
+
+```bash
+git add config/views.py config/urls.py
+git commit -m "feat(api): add api page view and URL route"
+```
+
+---
+
+## Task 8: Create API Page Template
+
+**Files:**
+- Create: `templates/api.html`
+
+**Step 1: Create the API page template**
+
+```html
+{% extends "base.html" %}
+
+{% block title %}API Access - CivicObserver{% endblock %}
+
+{% block content %}
+<!-- Hero Section -->
+<div class="bg-gradient-to-br from-gray-900 to-indigo-900 text-white">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
+        <div class="max-w-3xl">
+            <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight">
+                Access civic data<br>programmatically
+            </h1>
+            <p class="mt-6 text-xl text-gray-300">
+                CivicObserver provides API access to meeting documents, search results, and notification data for researchers, journalists, and civic tech developers.
+            </p>
+            <div class="mt-10 flex flex-col sm:flex-row gap-4">
+                <a href="{% url 'apikeys:list' %}" class="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-lg text-indigo-900 bg-white hover:bg-gray-100 transition-colors">
+                    Get Your API Key
+                </a>
+                <a href="https://docs.civic.band" target="_blank" rel="noopener" class="inline-flex items-center justify-center px-6 py-3 border border-white text-base font-medium rounded-lg text-white hover:bg-white/10 transition-colors">
+                    View Documentation
+                    <svg class="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
+                    </svg>
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Mission Section -->
+<div class="py-24 bg-white">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="max-w-3xl mx-auto text-center">
+            <h2 class="text-3xl font-bold text-gray-900">Built for transparency</h2>
+            <p class="mt-6 text-lg text-gray-600">
+                Local government decisions affect everyone. CivicObserver makes it easier to access, search, and monitor public meeting documents. Our API extends this mission by enabling researchers, journalists, and developers to build tools that further civic engagement.
+            </p>
+        </div>
+    </div>
+</div>
+
+<!-- Use Cases Section -->
+<div class="py-24 bg-gray-50">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h2 class="text-3xl font-bold text-gray-900 text-center mb-16">Who uses the API?</h2>
+
+        <div class="grid md:grid-cols-2 gap-8">
+            <!-- Researchers & Journalists -->
+            <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-200">
+                <div class="w-12 h-12 rounded-lg bg-indigo-100 flex items-center justify-center mb-6">
+                    <svg class="w-6 h-6 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+                    </svg>
+                </div>
+                <h3 class="text-xl font-semibold text-gray-900 mb-3">Researchers & Journalists</h3>
+                <p class="text-gray-600 mb-4">
+                    Analyze patterns in local government decision-making. Track how topics like housing, budget, or zoning evolve across municipalities over time.
+                </p>
+                <ul class="space-y-2 text-sm text-gray-600">
+                    <li class="flex items-start">
+                        <svg class="w-5 h-5 text-green-500 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                        </svg>
+                        Bulk export search results for analysis
+                    </li>
+                    <li class="flex items-start">
+                        <svg class="w-5 h-5 text-green-500 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                        </svg>
+                        Set up programmatic alerts for breaking topics
+                    </li>
+                    <li class="flex items-start">
+                        <svg class="w-5 h-5 text-green-500 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                        </svg>
+                        Access historical meeting data
+                    </li>
+                </ul>
+            </div>
+
+            <!-- Civic Tech Developers -->
+            <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-200">
+                <div class="w-12 h-12 rounded-lg bg-indigo-100 flex items-center justify-center mb-6">
+                    <svg class="w-6 h-6 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"></path>
+                    </svg>
+                </div>
+                <h3 class="text-xl font-semibold text-gray-900 mb-3">Civic Tech Developers</h3>
+                <p class="text-gray-600 mb-4">
+                    Build applications that help communities engage with local government. Create dashboards, notification bots, or analysis tools.
+                </p>
+                <ul class="space-y-2 text-sm text-gray-600">
+                    <li class="flex items-start">
+                        <svg class="w-5 h-5 text-green-500 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                        </svg>
+                        RESTful API with JSON responses
+                    </li>
+                    <li class="flex items-start">
+                        <svg class="w-5 h-5 text-green-500 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                        </svg>
+                        Webhook notifications for real-time updates
+                    </li>
+                    <li class="flex items-start">
+                        <svg class="w-5 h-5 text-green-500 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                        </svg>
+                        Rate limits suitable for most applications
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Getting Started Section -->
+<div class="py-24 bg-white">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <h2 class="text-3xl font-bold text-gray-900 text-center mb-16">Getting started</h2>
+
+        <div class="max-w-3xl mx-auto">
+            <div class="space-y-8">
+                <!-- Step 1 -->
+                <div class="flex gap-6">
+                    <div class="flex-shrink-0 w-10 h-10 rounded-full bg-indigo-600 text-white flex items-center justify-center font-bold">1</div>
+                    <div>
+                        <h3 class="text-lg font-semibold text-gray-900">Create an account</h3>
+                        <p class="mt-2 text-gray-600">Sign up for free to get access to the API. No credit card required.</p>
+                        <a href="{% url 'stagedoor:auth' %}" class="mt-3 inline-flex items-center text-indigo-600 font-medium hover:text-indigo-700">
+                            Sign up now
+                            <svg class="ml-1 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
+                            </svg>
+                        </a>
+                    </div>
+                </div>
+
+                <!-- Step 2 -->
+                <div class="flex gap-6">
+                    <div class="flex-shrink-0 w-10 h-10 rounded-full bg-indigo-600 text-white flex items-center justify-center font-bold">2</div>
+                    <div>
+                        <h3 class="text-lg font-semibold text-gray-900">Generate an API key</h3>
+                        <p class="mt-2 text-gray-600">Create an API key from your account dashboard. You can create multiple keys for different applications.</p>
+                        <a href="{% url 'apikeys:list' %}" class="mt-3 inline-flex items-center text-indigo-600 font-medium hover:text-indigo-700">
+                            Manage API keys
+                            <svg class="ml-1 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
+                            </svg>
+                        </a>
+                    </div>
+                </div>
+
+                <!-- Step 3 -->
+                <div class="flex gap-6">
+                    <div class="flex-shrink-0 w-10 h-10 rounded-full bg-indigo-600 text-white flex items-center justify-center font-bold">3</div>
+                    <div>
+                        <h3 class="text-lg font-semibold text-gray-900">Start making requests</h3>
+                        <p class="mt-2 text-gray-600">Use your API key to authenticate requests. Check our documentation for endpoints and examples.</p>
+                        <a href="https://docs.civic.band" target="_blank" rel="noopener" class="mt-3 inline-flex items-center text-indigo-600 font-medium hover:text-indigo-700">
+                            Read the docs
+                            <svg class="ml-1 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
+                            </svg>
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Code Example -->
+            <div class="mt-16">
+                <h3 class="text-lg font-semibold text-gray-900 mb-4">Example request</h3>
+                <div class="bg-gray-900 rounded-lg p-6 overflow-x-auto">
+                    <pre class="text-sm text-gray-300"><code>curl -H "Authorization: Bearer YOUR_API_KEY" \
+     "https://civic.observer/api/v1/search/?query=housing&municipality=berkeley"</code></pre>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- CTA Section -->
+<div class="bg-indigo-600">
+    <div class="max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:py-20 lg:px-8 text-center">
+        <h2 class="text-3xl font-extrabold text-white">Ready to get started?</h2>
+        <p class="mt-4 text-lg text-indigo-100 max-w-xl mx-auto">
+            Create a free account and start exploring the API today.
+        </p>
+        <div class="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
+            <a href="{% url 'stagedoor:auth' %}" class="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-lg text-indigo-600 bg-white hover:bg-gray-100 transition-colors">
+                Create Free Account
+            </a>
+            <a href="https://docs.civic.band" target="_blank" rel="noopener" class="inline-flex items-center justify-center px-6 py-3 border-2 border-white text-base font-medium rounded-lg text-white hover:bg-indigo-500 transition-colors">
+                Browse Documentation
+            </a>
+        </div>
+    </div>
+</div>
+{% endblock content %}
+```
+
+**Step 2: Verify the API page renders correctly**
+
+Visit http://localhost:8000/api/ and check all sections.
+
+**Step 3: Commit**
+
+```bash
+git add templates/api.html
+git commit -m "feat(api): create API information page for researchers and developers"
+```
+
+---
+
+## Task 9: Add API Link to Navigation
+
+**Files:**
+- Modify: `templates/base.html`
+
+**Step 1: Add API link to the desktop navigation**
+
+In the desktop nav section (around line 71), add after the notifications link for authenticated users:
+
+```html
+<a href="{% url 'api_page' %}" class="text-gray-600 hover:text-indigo-600 font-medium transition-colors" data-umami-event="nav_click" data-umami-event-destination="api">API</a>
+```
+
+**Step 2: Add API link to the mobile navigation**
+
+In the mobile menu section (around line 123), add:
+
+```html
+<a href="{% url 'api_page' %}" class="block px-3 py-2 rounded-md text-base font-medium text-gray-600 hover:text-indigo-600 hover:bg-gray-50 transition-colors" data-umami-event="nav_click" data-umami-event-destination="api">API</a>
+```
+
+**Step 3: Add API link to the footer**
+
+In the footer Platform section, add:
+
+```html
+<li>
+    <a href="{% url 'api_page' %}" class="text-base text-gray-400 hover:text-white transition-colors duration-200">
+        API Access
+    </a>
+</li>
+```
+
+**Step 4: Verify navigation links work**
+
+Check desktop and mobile navigation, and footer.
+
+**Step 5: Commit**
+
+```bash
+git add templates/base.html
+git commit -m "feat(marketing): add API page link to navigation and footer"
+```
+
+---
+
+## Task 10: Clean Up and Final Testing
+
+**Step 1: Run linting and type checking**
+
+```bash
+uv run --group dev ruff check .
+uv run --group dev mypy .
+```
+
+**Step 2: Fix any issues found**
+
+**Step 3: Test all pages manually**
+
+- Homepage: Check all feature demos work
+- API page: Check all sections and links
+- Navigation: Check desktop and mobile
+- Footer: Check API link
+
+**Step 4: Final commit if any cleanup needed**
+
+```bash
+git add -A
+git commit -m "chore(marketing): cleanup and formatting fixes"
+```
+
+---
+
+## Summary
+
+This plan creates:
+1. **Refreshed landing page** with hero + 4 alternating feature blocks
+2. **Interactive demos** using hardcoded JSON data (Search, Notebooks, Saved Searches)
+3. **Static demo** for Notifications feature
+4. **New /api page** with layered content for researchers/journalists
+5. **Updated navigation** with API link in header and footer
+
+All demos use client-side Alpine.js with hardcoded data, avoiding any database queries from bot traffic.

--- a/docs/plans/2025-12-05-utm-tracking-design.md
+++ b/docs/plans/2025-12-05-utm-tracking-design.md
@@ -1,0 +1,142 @@
+# UTM Tracking for Outbound Links
+
+## Overview
+
+Add UTM tracking parameters to civic ecosystem outbound links for attribution analytics, user journey tracking, and campaign measurement.
+
+## Goals
+
+1. **Attribution analytics** - Know which pages/features on civic.observer drive traffic to civic.band
+2. **User journey tracking** - Understand complete user flow when users navigate between properties
+3. **Campaign measurement** - Distinguish traffic sources for marketing campaigns
+
+## Solution
+
+### Template Tag: `{% civic_url %}`
+
+A Django template tag that adds UTM parameters to civic ecosystem URLs.
+
+**Location:** `analytics/templatetags/utm.py`
+
+**Syntax:**
+```django
+{% load utm %}
+
+<a href="{% civic_url page_url medium='search' campaign='search_results' content='view_button' %}">
+  View on CivicBand
+</a>
+```
+
+**Parameters:**
+| Parameter | Required | Description | Example Values |
+|-----------|----------|-------------|----------------|
+| `url` | Yes | The base URL to civic ecosystem | `https://alameda.ca.civic.band/...` |
+| `medium` | Yes | Type of interaction | `search`, `notebook`, `clip`, `email`, `nav` |
+| `campaign` | Yes | Feature/page context | `search_results`, `notebook_detail`, `clip_preview`, `weekly_digest`, `footer` |
+| `content` | No | UI element (default: `link`) | `view_button`, `document_link`, `header_link` |
+
+**Example output:**
+```
+https://alameda.ca.civic.band/meetings/agendas/abc123?utm_source=civicobserver&utm_medium=search&utm_campaign=search_results&utm_content=view_button
+```
+
+### UTM Parameter Structure
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| `utm_source` | `civicobserver` | Always this value |
+| `utm_medium` | varies | Type of interaction |
+| `utm_campaign` | varies | Feature/page context |
+| `utm_content` | varies | UI element clicked |
+
+### Tracked Domains
+
+The tag adds UTM params only to civic ecosystem domains:
+- `civic.band` (including subdomains like `alameda.ca.civic.band`)
+- `docs.civic.band`
+
+Non-civic URLs are returned unchanged.
+
+## Implementation Details
+
+### Domain Allowlist
+
+```python
+CIVIC_DOMAINS = [
+    "civic.band",
+    "docs.civic.band",
+]
+```
+
+### URL Parsing Logic
+
+1. Parse the URL with `urllib.parse.urlparse()`
+2. Check if domain ends with any allowlisted domain (handles subdomains)
+3. If match: parse existing query params, add UTM params, rebuild URL
+4. If no match: return original URL unchanged
+
+### Edge Cases
+
+| Case | Behavior |
+|------|----------|
+| URL with existing query params | UTM params appended |
+| URL with existing UTM params | Overwritten with new values |
+| Relative URL (`/path`) | Returned unchanged |
+| None/empty URL | Returns empty string |
+
+### Template Tag Registration
+
+```python
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag
+def civic_url(url, medium, campaign, content="link"): ...
+```
+
+## Templates to Update
+
+### High-traffic links (search & notebooks)
+- `meetings/partials/search_results.html` - "View on CivicBand" button
+- `notebooks/notebook_detail.html` - Links to original source documents
+- `clip/clip.html` - Clip editor links back to civic.band
+- `clip/partials/page_preview.html` - Preview and view links
+
+### Navigation & footer
+- `base.html` - Footer links to civic.band, docs.civic.band, terms, privacy
+
+### Email templates
+- `email/search_update.html` - Document links in search notifications
+- `email/digest_update.html` - If any civic.band links exist
+
+## Testing
+
+### Unit tests (`analytics/tests/test_utm.py`)
+
+1. **Civic ecosystem URLs get UTM params:**
+   - `civic.band` → params added
+   - `alameda.ca.civic.band` → params added
+   - `docs.civic.band` → params added
+
+2. **Non-civic URLs unchanged:**
+   - `google.com` → no params
+   - `civic.band.fake.com` → no params
+
+3. **Existing query params preserved:**
+   - `civic.band/page?foo=bar` → `civic.band/page?foo=bar&utm_source=...`
+
+4. **Edge cases:**
+   - Empty/None URL → returns empty string
+   - Relative URL → returned unchanged
+   - URL with existing UTM params → overwritten
+
+5. **Template integration test:**
+   - Render template using `{% civic_url %}`, verify output
+
+## Not Included (YAGNI)
+
+- JavaScript fallback for missed links
+- Admin UI for configuring domains/params
+- Analytics dashboard for viewing UTM data (handled by analytics platform)

--- a/docs/plans/2025-12-05-utm-tracking-implementation.md
+++ b/docs/plans/2025-12-05-utm-tracking-implementation.md
@@ -1,0 +1,676 @@
+# UTM Tracking Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add UTM tracking parameters to civic ecosystem outbound links for attribution analytics.
+
+**Architecture:** Django template tag `{% civic_url %}` that adds UTM parameters (utm_source, utm_medium, utm_campaign, utm_content) to URLs matching civic ecosystem domains. Server-side only, no JavaScript.
+
+**Tech Stack:** Django template tags, urllib.parse for URL manipulation, pytest for testing.
+
+---
+
+## Task 1: Create UTM Template Tag with Tests
+
+**Files:**
+- Create: `analytics/templatetags/utm.py`
+- Create: `tests/analytics/test_utm.py`
+
+### Step 1: Write the failing test for basic civic.band URL
+
+Create `tests/analytics/test_utm.py`:
+
+```python
+import pytest
+from django.template import Context, Template
+
+
+class TestCivicUrlTag:
+    def test_adds_utm_params_to_civic_band_url(self):
+        """civic_url tag adds UTM parameters to civic.band URLs."""
+        template = Template(
+            "{% load utm %}"
+            '{% civic_url "https://alameda.ca.civic.band/meetings/agendas/123" '
+            'medium="search" campaign="search_results" content="view_button" %}'
+        )
+        result = template.render(Context({}))
+
+        assert "utm_source=civicobserver" in result
+        assert "utm_medium=search" in result
+        assert "utm_campaign=search_results" in result
+        assert "utm_content=view_button" in result
+        assert result.startswith("https://alameda.ca.civic.band/meetings/agendas/123?")
+```
+
+### Step 2: Run test to verify it fails
+
+Run: `uv run pytest tests/analytics/test_utm.py -v`
+Expected: FAIL with "No module named 'analytics.templatetags.utm'" or similar
+
+### Step 3: Write minimal implementation
+
+Create `analytics/templatetags/utm.py`:
+
+```python
+"""Template tag for adding UTM parameters to civic ecosystem URLs."""
+
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+from django import template
+
+register = template.Library()
+
+# Domains that should receive UTM parameters
+CIVIC_DOMAINS = [
+    "civic.band",
+    "docs.civic.band",
+]
+
+
+def is_civic_domain(hostname: str) -> bool:
+    """Check if hostname belongs to civic ecosystem."""
+    if not hostname:
+        return False
+    for domain in CIVIC_DOMAINS:
+        if hostname == domain or hostname.endswith(f".{domain}"):
+            return True
+    return False
+
+
+@register.simple_tag
+def civic_url(
+    url: str,
+    medium: str,
+    campaign: str,
+    content: str = "link",
+) -> str:
+    """
+    Add UTM parameters to a civic ecosystem URL.
+
+    Usage:
+        {% load utm %}
+        {% civic_url page_url medium='search' campaign='search_results' content='view_button' %}
+
+    Returns the URL unchanged if it's not a civic ecosystem domain.
+    """
+    if not url:
+        return ""
+
+    try:
+        parsed = urlparse(url)
+    except (ValueError, AttributeError):
+        return url
+
+    # Only add UTM params to civic ecosystem domains
+    if not is_civic_domain(parsed.netloc):
+        return url
+
+    # Parse existing query parameters
+    query_params = parse_qs(parsed.query, keep_blank_values=True)
+
+    # Add/overwrite UTM parameters
+    utm_params = {
+        "utm_source": ["civicobserver"],
+        "utm_medium": [medium],
+        "utm_campaign": [campaign],
+        "utm_content": [content],
+    }
+    query_params.update(utm_params)
+
+    # Rebuild the URL
+    new_query = urlencode(query_params, doseq=True)
+    new_parsed = parsed._replace(query=new_query)
+
+    return urlunparse(new_parsed)
+```
+
+### Step 4: Run test to verify it passes
+
+Run: `uv run pytest tests/analytics/test_utm.py::TestCivicUrlTag::test_adds_utm_params_to_civic_band_url -v`
+Expected: PASS
+
+### Step 5: Add test for docs.civic.band
+
+Add to `tests/analytics/test_utm.py`:
+
+```python
+def test_adds_utm_params_to_docs_civic_band(self):
+    """civic_url tag adds UTM parameters to docs.civic.band URLs."""
+    template = Template(
+        "{% load utm %}"
+        '{% civic_url "https://docs.civic.band/api/reference" '
+        'medium="nav" campaign="footer" content="docs_link" %}'
+    )
+    result = template.render(Context({}))
+
+    assert "utm_source=civicobserver" in result
+    assert "utm_medium=nav" in result
+    assert "utm_campaign=footer" in result
+    assert "utm_content=docs_link" in result
+```
+
+### Step 6: Run test to verify it passes
+
+Run: `uv run pytest tests/analytics/test_utm.py::TestCivicUrlTag::test_adds_utm_params_to_docs_civic_band -v`
+Expected: PASS (implementation already handles this)
+
+### Step 7: Add test for non-civic URLs unchanged
+
+Add to `tests/analytics/test_utm.py`:
+
+```python
+def test_non_civic_url_unchanged(self):
+    """civic_url tag returns non-civic URLs unchanged."""
+    template = Template(
+        "{% load utm %}"
+        '{% civic_url "https://google.com/search" '
+        'medium="search" campaign="search_results" %}'
+    )
+    result = template.render(Context({}))
+
+    assert result == "https://google.com/search"
+    assert "utm_" not in result
+```
+
+### Step 8: Run test to verify it passes
+
+Run: `uv run pytest tests/analytics/test_utm.py::TestCivicUrlTag::test_non_civic_url_unchanged -v`
+Expected: PASS
+
+### Step 9: Add test for fake civic domain (security)
+
+Add to `tests/analytics/test_utm.py`:
+
+```python
+def test_fake_civic_domain_unchanged(self):
+    """civic_url tag doesn't add UTM to domains that look like civic.band but aren't."""
+    template = Template(
+        "{% load utm %}"
+        '{% civic_url "https://civic.band.fake.com/page" '
+        'medium="search" campaign="test" %}'
+    )
+    result = template.render(Context({}))
+
+    assert result == "https://civic.band.fake.com/page"
+    assert "utm_" not in result
+```
+
+### Step 10: Run test to verify it passes
+
+Run: `uv run pytest tests/analytics/test_utm.py::TestCivicUrlTag::test_fake_civic_domain_unchanged -v`
+Expected: PASS
+
+### Step 11: Add test for existing query params preserved
+
+Add to `tests/analytics/test_utm.py`:
+
+```python
+def test_preserves_existing_query_params(self):
+    """civic_url tag preserves existing query parameters."""
+    template = Template(
+        "{% load utm %}"
+        '{% civic_url "https://civic.band/page?foo=bar&baz=qux" '
+        'medium="search" campaign="test" %}'
+    )
+    result = template.render(Context({}))
+
+    assert "foo=bar" in result
+    assert "baz=qux" in result
+    assert "utm_source=civicobserver" in result
+```
+
+### Step 12: Run test to verify it passes
+
+Run: `uv run pytest tests/analytics/test_utm.py::TestCivicUrlTag::test_preserves_existing_query_params -v`
+Expected: PASS
+
+### Step 13: Add test for empty URL
+
+Add to `tests/analytics/test_utm.py`:
+
+```python
+def test_empty_url_returns_empty(self):
+    """civic_url tag returns empty string for empty URL."""
+    template = Template(
+        "{% load utm %}" '{% civic_url "" medium="search" campaign="test" %}'
+    )
+    result = template.render(Context({}))
+
+    assert result == ""
+```
+
+### Step 14: Run test to verify it passes
+
+Run: `uv run pytest tests/analytics/test_utm.py::TestCivicUrlTag::test_empty_url_returns_empty -v`
+Expected: PASS
+
+### Step 15: Add test for default content value
+
+Add to `tests/analytics/test_utm.py`:
+
+```python
+def test_default_content_value(self):
+    """civic_url tag uses 'link' as default content value."""
+    template = Template(
+        "{% load utm %}"
+        '{% civic_url "https://civic.band/page" '
+        'medium="search" campaign="test" %}'
+    )
+    result = template.render(Context({}))
+
+    assert "utm_content=link" in result
+```
+
+### Step 16: Run test to verify it passes
+
+Run: `uv run pytest tests/analytics/test_utm.py::TestCivicUrlTag::test_default_content_value -v`
+Expected: PASS
+
+### Step 17: Add test for template variable URL
+
+Add to `tests/analytics/test_utm.py`:
+
+```python
+def test_url_from_template_variable(self):
+    """civic_url tag works with URLs from template variables."""
+    template = Template(
+        "{% load utm %}"
+        '{% civic_url page_url medium="notebook" campaign="notebook_detail" %}'
+    )
+    result = template.render(
+        Context({"page_url": "https://oakland.ca.civic.band/meetings/minutes/456"})
+    )
+
+    assert "utm_source=civicobserver" in result
+    assert "utm_medium=notebook" in result
+    assert "utm_campaign=notebook_detail" in result
+```
+
+### Step 18: Run all UTM tests
+
+Run: `uv run pytest tests/analytics/test_utm.py -v`
+Expected: All tests PASS
+
+### Step 19: Commit
+
+```bash
+git add analytics/templatetags/utm.py tests/analytics/test_utm.py
+git commit -m "feat(analytics): add civic_url template tag for UTM tracking
+
+Adds a Django template tag that appends UTM parameters to civic ecosystem
+URLs (civic.band, docs.civic.band) for attribution analytics.
+
+- utm_source: always 'civicobserver'
+- utm_medium: type of interaction (search, notebook, email, nav)
+- utm_campaign: feature context (search_results, notebook_detail, etc.)
+- utm_content: UI element (view_button, link, etc.)"
+```
+
+---
+
+## Task 2: Update Search Results Template
+
+**Files:**
+- Modify: `templates/meetings/partials/search_results.html:128`
+
+### Step 1: Update the "View on CivicBand" link
+
+In `templates/meetings/partials/search_results.html`, find line 128 (the civic.band link) and update:
+
+Before:
+```html
+<a href="https://{{ result.document.municipality.subdomain }}.civic.band/meetings/{{ result.document.civic_band_table_name }}/{{ result.id }}"
+   target="_blank"
+   rel="noopener noreferrer"
+```
+
+After:
+```html
+{% load utm %}
+...
+<a href="{% civic_url 'https://'|add:result.document.municipality.subdomain|add:'.civic.band/meetings/'|add:result.document.civic_band_table_name|add:'/'|add:result.id medium='search' campaign='search_results' content='view_button' %}"
+   target="_blank"
+   rel="noopener noreferrer"
+```
+
+Note: The `{% load utm %}` should be added at the top of the file, after the existing `{% load ... %}` statement.
+
+### Step 2: Verify template renders correctly
+
+Run: `uv run pytest tests/searches/ -v -k "search"`
+Expected: PASS (existing tests should still pass)
+
+### Step 3: Commit
+
+```bash
+git add templates/meetings/partials/search_results.html
+git commit -m "feat(search): add UTM tracking to search result civic.band links"
+```
+
+---
+
+## Task 3: Update Notebook Detail Template
+
+**Files:**
+- Modify: `templates/notebooks/notebook_detail.html:102`
+
+### Step 1: Update the "View on CivicBand" link
+
+In `templates/notebooks/notebook_detail.html`, add `{% load utm %}` at line 1 and update line 102:
+
+Before:
+```html
+<a href="https://{{ entry.meeting_page.document.municipality.subdomain }}.civic.band/meetings/{{ entry.meeting_page.document.civic_band_table_name }}/{{ entry.meeting_page.id }}"
+   target="_blank"
+   rel="noopener noreferrer"
+```
+
+After:
+```html
+{% extends "base.html" %}
+{% load utm %}
+...
+<a href="{% civic_url 'https://'|add:entry.meeting_page.document.municipality.subdomain|add:'.civic.band/meetings/'|add:entry.meeting_page.document.civic_band_table_name|add:'/'|add:entry.meeting_page.id medium='notebook' campaign='notebook_detail' content='view_button' %}"
+   target="_blank"
+   rel="noopener noreferrer"
+```
+
+### Step 2: Verify template renders correctly
+
+Run: `uv run pytest tests/notebooks/ -v`
+Expected: PASS
+
+### Step 3: Commit
+
+```bash
+git add templates/notebooks/notebook_detail.html
+git commit -m "feat(notebooks): add UTM tracking to notebook civic.band links"
+```
+
+---
+
+## Task 4: Update Clip Templates
+
+**Files:**
+- Modify: `templates/clip/clip.html:33`
+- Modify: `templates/clip/partials/page_preview.html:30,135`
+- Modify: `templates/clip/partials/error.html:9`
+
+### Step 1: Update clip.html "Return to civic.band" link
+
+In `templates/clip/clip.html`, add `{% load utm %}` after line 2 (after `{% load analytics %}`) and update line 33:
+
+Before:
+```html
+<a href="https://civic.band"
+   class="text-indigo-600 hover:text-indigo-800 font-medium">
+    Return to civic.band
+</a>
+```
+
+After:
+```html
+<a href="{% civic_url 'https://civic.band' medium='clip' campaign='clip_missing_params' content='return_link' %}"
+   class="text-indigo-600 hover:text-indigo-800 font-medium">
+    Return to civic.band
+</a>
+```
+
+### Step 2: Update page_preview.html "View on civic.band" link (line 30)
+
+In `templates/clip/partials/page_preview.html`, add `{% load utm %}` at line 1 (before `{% load analytics %}`) and update line 30:
+
+Before:
+```html
+<a href="https://{{ subdomain }}.civic.band/{{ table }}/{{ page.document.meeting_name }}/{{ page.document.meeting_date|date:'Y-m-d' }}"
+   target="_blank"
+   rel="noopener noreferrer"
+```
+
+After:
+```html
+<a href="{% civic_url 'https://'|add:subdomain|add:'.civic.band/'|add:table|add:'/'|add:page.document.meeting_name|add:'/'|add:page.document.meeting_date|date:'Y-m-d' medium='clip' campaign='clip_preview' content='view_link' %}"
+   target="_blank"
+   rel="noopener noreferrer"
+```
+
+### Step 3: Update page_preview.html "Cancel" link (line 135)
+
+Before:
+```html
+<a href="https://{{ subdomain }}.civic.band"
+   class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50">
+    Cancel
+</a>
+```
+
+After:
+```html
+<a href="{% civic_url 'https://'|add:subdomain|add:'.civic.band' medium='clip' campaign='clip_preview' content='cancel_button' %}"
+   class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50">
+    Cancel
+</a>
+```
+
+### Step 4: Update error.html "Return to civic.band" link
+
+In `templates/clip/partials/error.html`, add `{% load utm %}` at line 1 and update line 9:
+
+Before:
+```html
+<a href="https://{{ subdomain }}.civic.band"
+   class="text-indigo-600 hover:text-indigo-800 font-medium">
+    Return to civic.band
+</a>
+```
+
+After:
+```html
+{% load utm %}
+...
+<a href="{% civic_url 'https://'|add:subdomain|add:'.civic.band' medium='clip' campaign='clip_error' content='return_link' %}"
+   class="text-indigo-600 hover:text-indigo-800 font-medium">
+    Return to civic.band
+</a>
+```
+
+### Step 5: Run clip tests
+
+Run: `uv run pytest tests/clip/ -v`
+Expected: PASS
+
+### Step 6: Commit
+
+```bash
+git add templates/clip/clip.html templates/clip/partials/page_preview.html templates/clip/partials/error.html
+git commit -m "feat(clip): add UTM tracking to clip civic.band links"
+```
+
+---
+
+## Task 5: Update Base Template Footer
+
+**Files:**
+- Modify: `templates/base.html:172,182,187`
+
+### Step 1: Add utm load to base.html
+
+At line 1, add `{% load utm %}` to the existing load statement:
+
+Before:
+```html
+{% load analytics static tailwind_cli %}
+```
+
+After:
+```html
+{% load analytics static tailwind_cli utm %}
+```
+
+### Step 2: Update CivicBand footer link (line 172)
+
+Before:
+```html
+<a href="https://civic.band" class="text-base text-gray-400 hover:text-white transition-colors duration-200" target="_blank" rel="noopener">
+    CivicBand
+</a>
+```
+
+After:
+```html
+<a href="{% civic_url 'https://civic.band' medium='nav' campaign='footer' content='civicband_link' %}" class="text-base text-gray-400 hover:text-white transition-colors duration-200" target="_blank" rel="noopener">
+    CivicBand
+</a>
+```
+
+### Step 3: Update Terms of Service link (line 182)
+
+Before:
+```html
+<a href="https://civic.band/terms" class="text-base text-gray-400 hover:text-white transition-colors duration-200" target="_blank" rel="noopener">
+    Terms of Service
+</a>
+```
+
+After:
+```html
+<a href="{% civic_url 'https://civic.band/terms' medium='nav' campaign='footer' content='terms_link' %}" class="text-base text-gray-400 hover:text-white transition-colors duration-200" target="_blank" rel="noopener">
+    Terms of Service
+</a>
+```
+
+### Step 4: Update Privacy Policy link (line 187)
+
+Before:
+```html
+<a href="https://civic.band/privacy" class="text-base text-gray-400 hover:text-white transition-colors duration-200" target="_blank" rel="noopener">
+    Privacy Policy
+</a>
+```
+
+After:
+```html
+<a href="{% civic_url 'https://civic.band/privacy' medium='nav' campaign='footer' content='privacy_link' %}" class="text-base text-gray-400 hover:text-white transition-colors duration-200" target="_blank" rel="noopener">
+    Privacy Policy
+</a>
+```
+
+### Step 5: Run a quick smoke test
+
+Run: `uv run pytest -v -k "test_" --maxfail=3`
+Expected: Tests pass (template changes shouldn't break functionality)
+
+### Step 6: Commit
+
+```bash
+git add templates/base.html
+git commit -m "feat(nav): add UTM tracking to footer civic.band links"
+```
+
+---
+
+## Task 6: Update Email Template
+
+**Files:**
+- Modify: `templates/email/search_update.html:169,199`
+
+### Step 1: Add utm load to email template
+
+At line 1, add:
+
+Before:
+```html
+{% load i18n %}
+```
+
+After:
+```html
+{% load i18n utm %}
+```
+
+### Step 2: Update meeting link in email (line 169)
+
+This is trickier because the URL is complex. The email template builds a civic.band URL with query params.
+
+Before:
+```html
+<a href="https://{{ page.document.municipality.subdomain }}.civic.band/meetings/{% if page.document.document_type == 'agenda' %}agendas{% else %}minutes{% endif %}?meeting={{ page.document.meeting_name|urlencode }}&date={{ page.document.meeting_date|date:'Y-m-d' }}">
+```
+
+For email templates with complex URLs, we need a different approach. Build the URL in steps:
+
+After:
+```html
+<a href="{% civic_url 'https://'|add:page.document.municipality.subdomain|add:'.civic.band/meetings/'|add:page.document.civic_band_table_name|add:'?meeting='|add:page.document.meeting_name|urlencode|add:'&date='|add:page.document.meeting_date|date:'Y-m-d' medium='email' campaign='search_update' content='result_link' %}">
+```
+
+Note: This is getting unwieldy. A simpler approach is to leave the URL as-is and just add UTM params at the end manually in the email template, OR create a helper that builds civic.band meeting URLs.
+
+**Alternative approach for emails:** Since email templates are complex, consider leaving the UTM as manual params appended:
+
+```html
+<a href="https://{{ page.document.municipality.subdomain }}.civic.band/meetings/{% if page.document.document_type == 'agenda' %}agendas{% else %}minutes{% endif %}?meeting={{ page.document.meeting_name|urlencode }}&date={{ page.document.meeting_date|date:'Y-m-d' }}&utm_source=civicobserver&utm_medium=email&utm_campaign=search_update&utm_content=result_link">
+```
+
+This is more readable and maintainable for email templates.
+
+### Step 3: Update civic.observer reference link (line 199)
+
+The link at line 199 points to civic.observer, not civic.band, so no UTM needed there.
+
+### Step 4: Commit
+
+```bash
+git add templates/email/search_update.html
+git commit -m "feat(email): add UTM tracking to search update email civic.band links"
+```
+
+---
+
+## Task 7: Run Full Test Suite and Verify
+
+### Step 1: Run all tests
+
+Run: `uv run pytest -v`
+Expected: All tests PASS
+
+### Step 2: Run linting
+
+Run: `uv run --group dev ruff check .`
+Expected: No errors
+
+### Step 3: Run type checking
+
+Run: `uv run --group dev mypy .`
+Expected: No errors (or only pre-existing ones)
+
+### Step 4: Manual verification (optional)
+
+Start the dev server and verify:
+1. Search for something, click "View on CivicBand" - URL should have UTM params
+2. Open a notebook, click "View on CivicBand" - URL should have UTM params
+3. Check footer links - should have UTM params
+
+### Step 5: Final commit if any fixes needed
+
+```bash
+git add -A
+git commit -m "fix: address any issues from testing"
+```
+
+---
+
+## Summary
+
+**Files created:**
+- `analytics/templatetags/utm.py` - The template tag
+- `tests/analytics/test_utm.py` - Unit tests
+
+**Files modified:**
+- `templates/meetings/partials/search_results.html` - Search results
+- `templates/notebooks/notebook_detail.html` - Notebook detail
+- `templates/clip/clip.html` - Clip main page
+- `templates/clip/partials/page_preview.html` - Clip preview
+- `templates/clip/partials/error.html` - Clip error
+- `templates/base.html` - Footer links
+- `templates/email/search_update.html` - Email notifications

--- a/templates/api.html
+++ b/templates/api.html
@@ -128,7 +128,7 @@
                         <div>
                             <h3 class="text-lg font-semibold text-gray-900">Create an account</h3>
                             <p class="mt-2 text-gray-600">Sign up for free to get access to the API. No credit card required.</p>
-                            <a href="{% url 'stagedoor:auth' %}" class="mt-3 inline-flex items-center text-indigo-600 font-medium hover:text-indigo-700">
+                            <a href="{% url 'stagedoor:login' %}" class="mt-3 inline-flex items-center text-indigo-600 font-medium hover:text-indigo-700">
                                 Sign up now
                                 <svg class="ml-1 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
@@ -188,7 +188,7 @@
                 Create a free account and start exploring the API today.
             </p>
             <div class="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
-                <a href="{% url 'stagedoor:auth' %}" class="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-lg text-indigo-600 bg-white hover:bg-gray-100 transition-colors">
+                <a href="{% url 'stagedoor:login' %}" class="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-lg text-indigo-600 bg-white hover:bg-gray-100 transition-colors">
                     Create Free Account
                 </a>
                 <a href="https://docs.civic.band" target="_blank" rel="noopener" class="inline-flex items-center justify-center px-6 py-3 border-2 border-white text-base font-medium rounded-lg text-white hover:bg-indigo-500 transition-colors">

--- a/templates/api.html
+++ b/templates/api.html
@@ -1,0 +1,200 @@
+{% extends "base.html" %}
+
+{% block title %}API Access - CivicObserver{% endblock %}
+
+{% block content %}
+<!-- Hero Section -->
+    <div class="bg-gradient-to-br from-gray-900 to-indigo-900 text-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
+            <div class="max-w-3xl">
+                <h1 class="text-4xl sm:text-5xl font-extrabold tracking-tight">
+                    Access civic data<br>programmatically
+                </h1>
+                <p class="mt-6 text-xl text-gray-300">
+                    CivicObserver provides API access to meeting documents, search results, and notification data for researchers, journalists, and civic tech developers.
+                </p>
+                <div class="mt-10 flex flex-col sm:flex-row gap-4">
+                    <a href="{% url 'apikeys:list' %}" class="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-lg text-indigo-900 bg-white hover:bg-gray-100 transition-colors">
+                        Get Your API Key
+                    </a>
+                    <a href="https://docs.civic.band" target="_blank" rel="noopener" class="inline-flex items-center justify-center px-6 py-3 border border-white text-base font-medium rounded-lg text-white hover:bg-white/10 transition-colors">
+                        View Documentation
+                        <svg class="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
+                        </svg>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+<!-- Mission Section -->
+    <div class="py-24 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="max-w-3xl mx-auto text-center">
+                <h2 class="text-3xl font-bold text-gray-900">Built for transparency</h2>
+                <p class="mt-6 text-lg text-gray-600">
+                    Local government decisions affect everyone. CivicObserver makes it easier to access, search, and monitor public meeting documents. Our API extends this mission by enabling researchers, journalists, and developers to build tools that further civic engagement.
+                </p>
+            </div>
+        </div>
+    </div>
+
+<!-- Use Cases Section -->
+    <div class="py-24 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <h2 class="text-3xl font-bold text-gray-900 text-center mb-16">Who uses the API?</h2>
+
+            <div class="grid md:grid-cols-2 gap-8">
+            <!-- Researchers & Journalists -->
+                <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-200">
+                    <div class="w-12 h-12 rounded-lg bg-indigo-100 flex items-center justify-center mb-6">
+                        <svg class="w-6 h-6 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+                        </svg>
+                    </div>
+                    <h3 class="text-xl font-semibold text-gray-900 mb-3">Researchers & Journalists</h3>
+                    <p class="text-gray-600 mb-4">
+                        Analyze patterns in local government decision-making. Track how topics like housing, budget, or zoning evolve across municipalities over time.
+                    </p>
+                    <ul class="space-y-2 text-sm text-gray-600">
+                        <li class="flex items-start">
+                            <svg class="w-5 h-5 text-green-500 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                            </svg>
+                            Bulk export search results for analysis
+                        </li>
+                        <li class="flex items-start">
+                            <svg class="w-5 h-5 text-green-500 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                            </svg>
+                            Set up programmatic alerts for breaking topics
+                        </li>
+                        <li class="flex items-start">
+                            <svg class="w-5 h-5 text-green-500 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                            </svg>
+                            Access historical meeting data
+                        </li>
+                    </ul>
+                </div>
+
+            <!-- Civic Tech Developers -->
+                <div class="bg-white rounded-xl p-8 shadow-sm border border-gray-200">
+                    <div class="w-12 h-12 rounded-lg bg-indigo-100 flex items-center justify-center mb-6">
+                        <svg class="w-6 h-6 text-indigo-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"></path>
+                        </svg>
+                    </div>
+                    <h3 class="text-xl font-semibold text-gray-900 mb-3">Civic Tech Developers</h3>
+                    <p class="text-gray-600 mb-4">
+                        Build applications that help communities engage with local government. Create dashboards, notification bots, or analysis tools.
+                    </p>
+                    <ul class="space-y-2 text-sm text-gray-600">
+                        <li class="flex items-start">
+                            <svg class="w-5 h-5 text-green-500 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                            </svg>
+                            RESTful API with JSON responses
+                        </li>
+                        <li class="flex items-start">
+                            <svg class="w-5 h-5 text-green-500 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                            </svg>
+                            Webhook notifications for real-time updates
+                        </li>
+                        <li class="flex items-start">
+                            <svg class="w-5 h-5 text-green-500 mr-2 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
+                            </svg>
+                            Rate limits suitable for most applications
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+
+<!-- Getting Started Section -->
+    <div class="py-24 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <h2 class="text-3xl font-bold text-gray-900 text-center mb-16">Getting started</h2>
+
+            <div class="max-w-3xl mx-auto">
+                <div class="space-y-8">
+                <!-- Step 1 -->
+                    <div class="flex gap-6">
+                        <div class="flex-shrink-0 w-10 h-10 rounded-full bg-indigo-600 text-white flex items-center justify-center font-bold">1</div>
+                        <div>
+                            <h3 class="text-lg font-semibold text-gray-900">Create an account</h3>
+                            <p class="mt-2 text-gray-600">Sign up for free to get access to the API. No credit card required.</p>
+                            <a href="{% url 'stagedoor:auth' %}" class="mt-3 inline-flex items-center text-indigo-600 font-medium hover:text-indigo-700">
+                                Sign up now
+                                <svg class="ml-1 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
+                                </svg>
+                            </a>
+                        </div>
+                    </div>
+
+                <!-- Step 2 -->
+                    <div class="flex gap-6">
+                        <div class="flex-shrink-0 w-10 h-10 rounded-full bg-indigo-600 text-white flex items-center justify-center font-bold">2</div>
+                        <div>
+                            <h3 class="text-lg font-semibold text-gray-900">Generate an API key</h3>
+                            <p class="mt-2 text-gray-600">Create an API key from your account dashboard. You can create multiple keys for different applications.</p>
+                            <a href="{% url 'apikeys:list' %}" class="mt-3 inline-flex items-center text-indigo-600 font-medium hover:text-indigo-700">
+                                Manage API keys
+                                <svg class="ml-1 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
+                                </svg>
+                            </a>
+                        </div>
+                    </div>
+
+                <!-- Step 3 -->
+                    <div class="flex gap-6">
+                        <div class="flex-shrink-0 w-10 h-10 rounded-full bg-indigo-600 text-white flex items-center justify-center font-bold">3</div>
+                        <div>
+                            <h3 class="text-lg font-semibold text-gray-900">Start making requests</h3>
+                            <p class="mt-2 text-gray-600">Use your API key to authenticate requests. Check our documentation for endpoints and examples.</p>
+                            <a href="https://docs.civic.band" target="_blank" rel="noopener" class="mt-3 inline-flex items-center text-indigo-600 font-medium hover:text-indigo-700">
+                                Read the docs
+                                <svg class="ml-1 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"></path>
+                                </svg>
+                            </a>
+                        </div>
+                    </div>
+                </div>
+
+            <!-- Code Example -->
+                <div class="mt-16">
+                    <h3 class="text-lg font-semibold text-gray-900 mb-4">Example request</h3>
+                    <div class="bg-gray-900 rounded-lg p-6 overflow-x-auto">
+                    <pre class="text-sm text-gray-300"><code>curl -H "Authorization: Bearer YOUR_API_KEY" \
+     "https://civic.observer/api/v1/search/?query=housing&municipality=berkeley"</code></pre>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+<!-- CTA Section -->
+    <div class="bg-indigo-600">
+        <div class="max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:py-20 lg:px-8 text-center">
+            <h2 class="text-3xl font-extrabold text-white">Ready to get started?</h2>
+            <p class="mt-4 text-lg text-indigo-100 max-w-xl mx-auto">
+                Create a free account and start exploring the API today.
+            </p>
+            <div class="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
+                <a href="{% url 'stagedoor:auth' %}" class="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-lg text-indigo-600 bg-white hover:bg-gray-100 transition-colors">
+                    Create Free Account
+                </a>
+                <a href="https://docs.civic.band" target="_blank" rel="noopener" class="inline-flex items-center justify-center px-6 py-3 border-2 border-white text-base font-medium rounded-lg text-white hover:bg-indigo-500 transition-colors">
+                    Browse Documentation
+                </a>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -75,6 +75,7 @@
                                     <a href="{% url 'apikeys:list' %}" class="text-gray-600 hover:text-indigo-600 font-medium transition-colors" data-umami-event="nav_click" data-umami-event-destination="api_keys">API Keys</a>
                                     <a href="{% url 'notifications:channel-list' %}" class="text-gray-600 hover:text-indigo-600 font-medium transition-colors" data-umami-event="nav_click" data-umami-event-destination="notifications">Notifications</a>
                                 {% endif %}
+                                <a href="{% url 'api_page' %}" class="text-gray-600 hover:text-indigo-600 font-medium transition-colors" data-umami-event="nav_click" data-umami-event-destination="api">API</a>
                                 {% if user.is_staff %} <a href="{% url 'admin:index' %}" class="text-gray-600 hover:text-indigo-600 font-medium transition-colors" data-umami-event="nav_click" data-umami-event-destination="admin">Admin</a> {% endif %}
                             </div>
                         </div>
@@ -122,6 +123,7 @@
                                 <a href="{% url 'apikeys:list' %}" class="block px-3 py-2 rounded-md text-base font-medium text-gray-600 hover:text-indigo-600 hover:bg-gray-50 transition-colors" data-umami-event="nav_click" data-umami-event-destination="api_keys">API Keys</a>
                                 <a href="{% url 'notifications:channel-list' %}" class="block px-3 py-2 rounded-md text-base font-medium text-gray-600 hover:text-indigo-600 hover:bg-gray-50 transition-colors" data-umami-event="nav_click" data-umami-event-destination="notifications">Notifications</a>
                             {% endif %}
+                            <a href="{% url 'api_page' %}" class="block px-3 py-2 rounded-md text-base font-medium text-gray-600 hover:text-indigo-600 hover:bg-gray-50 transition-colors" data-umami-event="nav_click" data-umami-event-destination="api">API</a>
                             {% if user.is_staff %}
                                 <a href="{% url 'admin:index' %}" class="block px-3 py-2 rounded-md text-base font-medium text-gray-600 hover:text-indigo-600 hover:bg-gray-50 transition-colors" data-umami-event="nav_click" data-umami-event-destination="admin">Admin</a>
                             {% endif %}
@@ -159,6 +161,11 @@
                                         <li>
                                             <a href="{% url 'homepage' %}#features" class="text-base text-gray-400 hover:text-white transition-colors duration-200">
                                                 Features
+                                            </a>
+                                        </li>
+                                        <li>
+                                            <a href="{% url 'api_page' %}" class="text-base text-gray-400 hover:text-white transition-colors duration-200">
+                                                API Access
                                             </a>
                                         </li>
                                         <li>

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,4 +1,4 @@
-{% load analytics static tailwind_cli %}
+{% load analytics static tailwind_cli utm %}
 <!DOCTYPE html>
 <html lang="en" class="h-full">
     <head>
@@ -169,7 +169,7 @@
                                             </a>
                                         </li>
                                         <li>
-                                            <a href="https://civic.band" class="text-base text-gray-400 hover:text-white transition-colors duration-200" target="_blank" rel="noopener">
+                                            <a href="{% civic_url 'https://civic.band' medium='nav' campaign='footer' content='civicband_link' %}" class="text-base text-gray-400 hover:text-white transition-colors duration-200" target="_blank" rel="noopener">
                                                 CivicBand
                                             </a>
                                         </li>
@@ -179,12 +179,12 @@
                                     <h3 class="text-sm font-semibold text-gray-300 tracking-wider uppercase">Legal</h3>
                                     <ul class="mt-4 space-y-4">
                                         <li>
-                                            <a href="https://civic.band/terms" class="text-base text-gray-400 hover:text-white transition-colors duration-200" target="_blank" rel="noopener">
+                                            <a href="{% civic_url 'https://civic.band/terms' medium='nav' campaign='footer' content='terms_link' %}" class="text-base text-gray-400 hover:text-white transition-colors duration-200" target="_blank" rel="noopener">
                                                 Terms of Service
                                             </a>
                                         </li>
                                         <li>
-                                            <a href="https://civic.band/privacy" class="text-base text-gray-400 hover:text-white transition-colors duration-200" target="_blank" rel="noopener">
+                                            <a href="{% civic_url 'https://civic.band/privacy' medium='nav' campaign='footer' content='privacy_link' %}" class="text-base text-gray-400 hover:text-white transition-colors duration-200" target="_blank" rel="noopener">
                                                 Privacy Policy
                                             </a>
                                         </li>

--- a/templates/clip/clip.html
+++ b/templates/clip/clip.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load analytics %}
+{% load analytics utm %}
 
 {% block title %}Save to Notebook - CivicObserver{% endblock %}
 
@@ -30,7 +30,7 @@
                             This page requires id, subdomain, and table parameters.
                         </p>
                         <div class="mt-6">
-                            <a href="https://civic.band"
+                            <a href="{% civic_url 'https://civic.band' medium='clip' campaign='clip_missing_params' content='return_link' %}"
                                class="text-indigo-600 hover:text-indigo-800 font-medium">
                                 Return to civic.band
                             </a>

--- a/templates/clip/partials/error.html
+++ b/templates/clip/partials/error.html
@@ -1,3 +1,4 @@
+{% load utm %}
 <div class="text-center py-8">
     <svg class="mx-auto h-12 w-12 text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -6,7 +7,7 @@
     <p class="mt-1 text-sm text-gray-500">{{ message }}</p>
     {% if subdomain %}
         <div class="mt-6">
-            <a href="https://{{ subdomain }}.civic.band"
+            <a href="{% civic_url 'https://'|add:subdomain|add:'.civic.band' medium='clip' campaign='clip_error' content='return_link' %}"
                class="text-indigo-600 hover:text-indigo-800 font-medium">
                 Return to civic.band
             </a>

--- a/templates/clip/partials/page_preview.html
+++ b/templates/clip/partials/page_preview.html
@@ -1,4 +1,4 @@
-{% load analytics %}
+{% load analytics utm %}
 <div class="space-y-6">
     <!-- Meeting Preview -->
     <div class="border border-gray-200 rounded-lg p-4 bg-gray-50">
@@ -27,7 +27,7 @@
             </div>
         {% endif %}
 
-        <a href="https://{{ subdomain }}.civic.band/{{ table }}/{{ page.document.meeting_name }}/{{ page.document.meeting_date|date:'Y-m-d' }}"
+        <a href="{% civic_url 'https://'|add:subdomain|add:'.civic.band/'|add:table|add:'/'|add:page.document.meeting_name|add:'/'|add:page.document.meeting_date|date:'Y-m-d' medium='clip' campaign='clip_preview' content='view_link' %}"
            target="_blank"
            rel="noopener noreferrer"
            class="mt-3 inline-flex items-center text-sm text-indigo-600 hover:text-indigo-800">
@@ -132,7 +132,7 @@
 
         <!-- Actions -->
         <div class="flex items-center justify-end gap-3 pt-4 border-t border-gray-200">
-            <a href="https://{{ subdomain }}.civic.band"
+            <a href="{% civic_url 'https://'|add:subdomain|add:'.civic.band' medium='clip' campaign='clip_preview' content='cancel_button' %}"
                class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50">
                 Cancel
             </a>

--- a/templates/email/search_update.html
+++ b/templates/email/search_update.html
@@ -1,4 +1,4 @@
-{% load i18n %}
+{% load i18n utm %}
 
 <!DOCTYPE html>
 <html lang="en" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
@@ -166,7 +166,7 @@
                                                                 <ul style="padding-left: 20px;">
                                                                     {% for page in new_pages|slice:":10" %}
                                                                         <li style="margin-bottom: 12px;">
-                                                                            <a href="https://{{ page.document.municipality.subdomain }}.civic.band/meetings/{% if page.document.document_type == 'agenda' %}agendas{% else %}minutes{% endif %}?meeting={{ page.document.meeting_name|urlencode }}&date={{ page.document.meeting_date|date:'Y-m-d' }}">
+                                                                            <a href="https://{{ page.document.municipality.subdomain }}.civic.band/meetings/{% if page.document.document_type == 'agenda' %}agendas{% else %}minutes{% endif %}?meeting={{ page.document.meeting_name|urlencode }}&date={{ page.document.meeting_date|date:'Y-m-d' }}&utm_source=civicobserver&utm_medium=email&utm_campaign=search_update&utm_content=result_link">
                                                                                 <strong>{{ page.document.meeting_name }}</strong> - {{ page.document.meeting_date|date:"M d, Y" }}
                                                                                 <br>
                                                                                 <span style="color: #666; font-size: 14px;">

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -36,9 +36,9 @@
     </div>
 
 <!-- Feature 1: Search -->
-    <div id="features" class="py-20 lg:py-32 bg-white border-t border-gray-100">
+    <div id="features" class="py-16 lg:py-24 bg-white border-t border-gray-100">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="lg:grid lg:grid-cols-2 lg:gap-20 items-center">
+            <div class="lg:grid lg:grid-cols-2 lg:gap-16 items-center">
             <!-- Text Content -->
                 <div>
                     <div class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-indigo-100 text-indigo-800 mb-4">
@@ -104,9 +104,9 @@
     </div>
 
 <!-- Feature 2: Notebooks -->
-    <div class="py-20 lg:py-32 bg-gray-50 border-t border-gray-200">
+    <div class="py-16 lg:py-24 bg-gray-50 border-t border-gray-200">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="lg:grid lg:grid-cols-2 lg:gap-20 items-center">
+            <div class="lg:grid lg:grid-cols-2 lg:gap-16 items-center">
             <!-- Interactive Demo (Left side) -->
                 <div class="order-2 lg:order-1 mt-12 lg:mt-0" x-data="notebookDemo()">
                     <div class="bg-white rounded-2xl p-6 shadow-lg border border-gray-200">
@@ -179,9 +179,9 @@
     </div>
 
 <!-- Feature 3: Saved Searches -->
-    <div class="py-20 lg:py-32 bg-white border-t border-gray-100">
+    <div class="py-16 lg:py-24 bg-white border-t border-gray-100">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="lg:grid lg:grid-cols-2 lg:gap-20 items-center">
+            <div class="lg:grid lg:grid-cols-2 lg:gap-16 items-center">
             <!-- Text Content -->
                 <div>
                     <div class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-indigo-100 text-indigo-800 mb-4">
@@ -253,9 +253,9 @@
     </div>
 
 <!-- Feature 4: Notifications (Static) -->
-    <div class="py-20 lg:py-32 bg-gray-50 border-t border-gray-200">
+    <div class="py-16 lg:py-24 bg-gray-50 border-t border-gray-200">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="lg:grid lg:grid-cols-2 lg:gap-20 items-center">
+            <div class="lg:grid lg:grid-cols-2 lg:gap-16 items-center">
             <!-- Static Preview (Left side) -->
                 <div class="order-2 lg:order-1 mt-12 lg:mt-0">
                     <div class="bg-white rounded-2xl p-6 shadow-lg border border-gray-200">

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -340,19 +340,24 @@
         </div>
     </div>
 
-<!-- CTA Section -->
-    <div class="bg-indigo-50">
-        <div class="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:py-16 lg:px-8 lg:flex lg:items-center lg:justify-between">
-            <h2 class="text-3xl font-extrabold tracking-tight text-gray-900 sm:text-4xl">
-                <span class="block">Ready to set up your alerts?</span>
-                <span class="block text-indigo-600">Start monitoring what matters to you.</span>
-            </h2>
-            <div class="mt-8 flex lg:mt-0 lg:flex-shrink-0">
-                <div class="inline-flex rounded-md shadow">
-                    <a href="{% url 'munis:muni-list' %}" class="inline-flex items-center justify-center px-5 py-3 border border-transparent text-base font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 transition-colors duration-200">
-                        Browse Municipalities
-                    </a>
-                </div>
+<!-- Final CTA -->
+    <div class="bg-indigo-600">
+        <div class="max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:py-24 lg:px-8 lg:flex lg:items-center lg:justify-between">
+            <div>
+                <h2 class="text-3xl font-extrabold tracking-tight text-white sm:text-4xl">
+                    Ready to stay informed?
+                </h2>
+                <p class="mt-4 text-lg text-indigo-100 max-w-xl">
+                    Join researchers, journalists, and engaged citizens who use CivicObserver to track local government.
+                </p>
+            </div>
+            <div class="mt-8 flex flex-col sm:flex-row gap-4 lg:mt-0 lg:flex-shrink-0">
+                <a href="{% url 'stagedoor:auth' %}" class="inline-flex items-center justify-center px-6 py-4 border border-transparent text-lg font-medium rounded-lg text-indigo-600 bg-white hover:bg-indigo-50 shadow-lg transition-all duration-200">
+                    Get Started Free
+                </a>
+                <a href="{% url 'meetings:meeting-search' %}" class="inline-flex items-center justify-center px-6 py-4 border-2 border-white text-lg font-medium rounded-lg text-white hover:bg-indigo-500 transition-all duration-200">
+                    Try Search First
+                </a>
             </div>
         </div>
     </div>

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -252,6 +252,94 @@
         </div>
     </div>
 
+<!-- Feature 4: Notifications (Static) -->
+    <div class="py-24 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="lg:grid lg:grid-cols-2 lg:gap-16 items-center">
+            <!-- Static Preview (Left side) -->
+                <div class="order-2 lg:order-1 mt-12 lg:mt-0">
+                    <div class="bg-white rounded-2xl p-6 shadow-lg border border-gray-200">
+                        <h3 class="font-semibold text-gray-900 mb-4">Notification Channels</h3>
+
+                        <div class="space-y-4">
+                        <!-- Email Channel -->
+                            <div class="flex items-center justify-between p-4 rounded-lg border border-gray-200">
+                                <div class="flex items-center">
+                                    <div class="w-10 h-10 rounded-full bg-blue-100 flex items-center justify-center mr-4">
+                                        <svg class="w-5 h-5 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+                                        </svg>
+                                    </div>
+                                    <div>
+                                        <p class="font-medium text-gray-900">Email</p>
+                                        <p class="text-sm text-gray-500">researcher@example.com</p>
+                                    </div>
+                                </div>
+                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Active</span>
+                            </div>
+
+                        <!-- Bluesky Channel -->
+                            <div class="flex items-center justify-between p-4 rounded-lg border border-gray-200">
+                                <div class="flex items-center">
+                                    <div class="w-10 h-10 rounded-full bg-sky-100 flex items-center justify-center mr-4">
+                                        <svg class="w-5 h-5 text-sky-600" viewBox="0 0 24 24" fill="currentColor">
+                                            <path d="M12 2C6.477 2 2 6.477 2 12c0 4.991 3.657 9.128 8.438 9.879V14.89h-2.54V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.89h-2.33v6.989C18.343 21.129 22 16.99 22 12c0-5.523-4.477-10-10-10z"/>
+                                        </svg>
+                                    </div>
+                                    <div>
+                                        <p class="font-medium text-gray-900">Bluesky</p>
+                                        <p class="text-sm text-gray-500">@researcher.bsky.social</p>
+                                    </div>
+                                </div>
+                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Active</span>
+                            </div>
+
+                        <!-- Webhook Channel -->
+                            <div class="flex items-center justify-between p-4 rounded-lg border border-dashed border-gray-300 bg-gray-50">
+                                <div class="flex items-center">
+                                    <div class="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center mr-4">
+                                        <svg class="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"></path>
+                                        </svg>
+                                    </div>
+                                    <div>
+                                        <p class="font-medium text-gray-500">Webhook</p>
+                                        <p class="text-sm text-gray-400">For developers & integrations</p>
+                                    </div>
+                                </div>
+                                <span class="text-sm text-gray-500">Coming soon</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+            <!-- Text Content (Right side) -->
+                <div class="order-1 lg:order-2">
+                    <div class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-indigo-100 text-indigo-800 mb-4">
+                        <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"></path>
+                        </svg>
+                        Notifications
+                    </div>
+                    <h2 class="text-3xl font-bold text-gray-900 sm:text-4xl">
+                        Get alerted your way
+                    </h2>
+                    <p class="mt-4 text-lg text-gray-600">
+                        Choose how you want to receive updates. Get instant email notifications, post to Bluesky, or integrate with your own systems via webhooks.
+                    </p>
+                    <div class="mt-8">
+                        <a href="{% url 'notifications:channel-list' %}" class="inline-flex items-center text-indigo-600 font-medium hover:text-indigo-700">
+                            Configure your notifications
+                            <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
+                            </svg>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
 <!-- CTA Section -->
     <div class="bg-indigo-50">
         <div class="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:py-16 lg:px-8 lg:flex lg:items-center lg:justify-between">

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -103,6 +103,81 @@
         </div>
     </div>
 
+<!-- Feature 2: Notebooks -->
+    <div class="py-24 bg-gray-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="lg:grid lg:grid-cols-2 lg:gap-16 items-center">
+            <!-- Interactive Demo (Left side) -->
+                <div class="order-2 lg:order-1 mt-12 lg:mt-0" x-data="notebookDemo()">
+                    <div class="bg-white rounded-2xl p-6 shadow-lg border border-gray-200">
+                        <div class="flex items-center justify-between mb-4">
+                            <h3 class="font-semibold text-gray-900">My Research Notebook</h3>
+                            <span class="text-sm text-gray-500" x-text="savedPages.length + ' pages'"></span>
+                        </div>
+
+                        <div class="space-y-3 max-h-64 overflow-y-auto">
+                            <template x-for="page in savedPages" :key="page.id">
+                                <div class="p-4 rounded-lg border border-gray-200 hover:border-indigo-300 transition-colors">
+                                    <div class="flex items-start justify-between">
+                                        <div class="flex-1 min-w-0">
+                                            <p class="text-sm font-medium text-gray-900" x-text="page.title"></p>
+                                            <p class="text-xs text-gray-500 mt-1" x-text="page.source"></p>
+                                        </div>
+                                        <button @click="removePage(page.id)"
+                                                class="ml-2 text-gray-400 hover:text-red-500 transition-colors">
+                                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                                            </svg>
+                                        </button>
+                                    </div>
+                                    <div class="mt-2 flex flex-wrap gap-1">
+                                        <template x-for="tag in page.tags" :key="tag">
+                                            <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-700" x-text="tag"></span>
+                                        </template>
+                                    </div>
+                                </div>
+                            </template>
+                        </div>
+
+                        <div class="mt-4 pt-4 border-t border-gray-200">
+                            <button @click="addSamplePage()"
+                                    class="w-full inline-flex items-center justify-center px-4 py-2 border border-dashed border-gray-300 rounded-lg text-sm text-gray-600 hover:border-indigo-500 hover:text-indigo-600 transition-colors">
+                                <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+                                </svg>
+                                Save another page
+                            </button>
+                        </div>
+                    </div>
+                </div>
+
+            <!-- Text Content (Right side) -->
+                <div class="order-1 lg:order-2">
+                    <div class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-indigo-100 text-indigo-800 mb-4">
+                        <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"></path>
+                        </svg>
+                        Notebooks
+                    </div>
+                    <h2 class="text-3xl font-bold text-gray-900 sm:text-4xl">
+                        Save and organize your research
+                    </h2>
+                    <p class="mt-4 text-lg text-gray-600">
+                        Clip important pages from meeting documents directly to your notebooks. Tag them, organize them, and access them anytime. Perfect for journalists, researchers, and engaged citizens.
+                    </p>
+                    <div class="mt-8">
+                        <a href="{% url 'notebooks:notebook-list' %}" class="inline-flex items-center text-indigo-600 font-medium hover:text-indigo-700">
+                            Create your first notebook
+                            <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
+                            </svg>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
 <!-- CTA Section -->
     <div class="bg-indigo-50">
         <div class="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:py-16 lg:px-8 lg:flex lg:items-center lg:justify-between">
@@ -183,6 +258,50 @@
                         r.snippet.toLowerCase().includes(q) ||
                         r.municipality.toLowerCase().includes(q)
                     );
+                }
+            };
+        }
+
+        function notebookDemo() {
+            return {
+                savedPages: [
+                    {
+                        id: 1,
+                        title: 'Budget Discussion - FY2025 Allocations',
+                        source: 'Berkeley City Council • Nov 15, 2024',
+                        tags: ['budget', 'housing']
+                    },
+                    {
+                        id: 2,
+                        title: 'Zoning Amendment Review',
+                        source: 'Oakland Planning Commission • Nov 12, 2024',
+                        tags: ['zoning', 'development']
+                    },
+                    {
+                        id: 3,
+                        title: 'Affordable Housing Initiatives',
+                        source: 'SF Housing Authority • Nov 10, 2024',
+                        tags: ['housing', 'affordable']
+                    }
+                ],
+                nextId: 4,
+                samplePages: [
+                    { title: 'Transit Funding Discussion', source: 'BART Board • Nov 1, 2024', tags: ['transit', 'budget'] },
+                    { title: 'Environmental Impact Review', source: 'County Planning • Oct 28, 2024', tags: ['environment'] },
+                    { title: 'Public Safety Committee Report', source: 'City Council • Oct 25, 2024', tags: ['safety'] }
+                ],
+
+                removePage(id) {
+                    this.savedPages = this.savedPages.filter(p => p.id !== id);
+                },
+
+                addSamplePage() {
+                    if (this.samplePages.length === 0) return;
+                    const page = this.samplePages.shift();
+                    this.savedPages.push({
+                        id: this.nextId++,
+                        ...page
+                    });
                 }
             };
         }

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -35,105 +35,70 @@
         </div>
     </div>
 
-<!-- Features Section -->
-    <div id="features" class="py-16 bg-gray-50">
+<!-- Feature 1: Search -->
+    <div id="features" class="py-24 bg-white">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="lg:text-center">
-                <h2 class="text-base text-indigo-600 font-semibold tracking-wide uppercase">Smart Alerting System</h2>
-                <p class="mt-2 text-3xl leading-8 font-extrabold tracking-tight text-gray-900 sm:text-4xl">
-                    Never miss what matters to you
-                </p>
-                <p class="mt-4 max-w-2xl text-xl text-gray-500 lg:mx-auto">
-                    Set up alerts for any CivicBand site or search term and get notified instantly when new content matches your interests.
-                </p>
-            </div>
-
-            <div class="mt-16">
-                <dl class="space-y-10 md:space-y-0 md:grid md:grid-cols-2 md:gap-x-8 md:gap-y-10 lg:grid-cols-3">
-                    <div class="relative">
-                        <dt>
-                            <div class="absolute flex items-center justify-center h-12 w-12 rounded-md bg-indigo-500 text-white">
-                                <svg aria-hidden="true" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-5 5v-5zM15 17l-5-5H5a2 2 0 01-2-2V5a2 2 0 012-2h14a2 2 0 012 2v5a2 2 0 01-2 2h-5z"></path>
-                                </svg>
-                            </div>
-                            <p class="ml-16 text-lg leading-6 font-medium text-gray-900">Municipality Alerts</p>
-                        </dt>
-                        <dd class="mt-2 ml-16 text-base text-gray-500">
-                            Follow CivicBand sites and get instant alerts for new meetings, documents, and minutes.
-                        </dd>
+            <div class="lg:grid lg:grid-cols-2 lg:gap-16 items-center">
+            <!-- Text Content -->
+                <div>
+                    <div class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-indigo-100 text-indigo-800 mb-4">
+                        <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+                        </svg>
+                        Search
                     </div>
-
-                    <div class="relative">
-                        <dt>
-                            <div class="absolute flex items-center justify-center h-12 w-12 rounded-md bg-indigo-500 text-white">
-                                <svg aria-hidden="true" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
-                                </svg>
-                            </div>
-                            <p class="ml-16 text-lg leading-6 font-medium text-gray-900">Saved Search Alerts</p>
-                        </dt>
-                        <dd class="mt-2 ml-16 text-base text-gray-500">
-                            Save any search term like "budget", "housing", or "zoning" and get notified when new content matches.
-                        </dd>
+                    <h2 class="text-3xl font-bold text-gray-900 sm:text-4xl">
+                        Find what matters in meeting documents
+                    </h2>
+                    <p class="mt-4 text-lg text-gray-600">
+                        Search across thousands of meeting agendas and minutes from municipalities across the country. Use powerful filters to narrow down by date, location, or document type.
+                    </p>
+                    <div class="mt-8">
+                        <a href="{% url 'meetings:meeting-search' %}" class="inline-flex items-center text-indigo-600 font-medium hover:text-indigo-700">
+                            Try searching now
+                            <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
+                            </svg>
+                        </a>
                     </div>
+                </div>
 
-                    <div class="relative">
-                        <dt>
-                            <div class="absolute flex items-center justify-center h-12 w-12 rounded-md bg-indigo-500 text-white">
-                                <svg aria-hidden="true" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                                </svg>
+            <!-- Interactive Demo -->
+                <div class="mt-12 lg:mt-0" x-data="searchDemo()">
+                    <div class="bg-gray-50 rounded-2xl p-6 shadow-lg border border-gray-200">
+                        <div class="flex items-center gap-3 mb-4">
+                            <div class="flex-1">
+                                <input type="text"
+                                       x-model="query"
+                                       @input="filterResults()"
+                                       placeholder="Try searching: budget, housing, zoning..."
+                                       class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
                             </div>
-                            <p class="ml-16 text-lg leading-6 font-medium text-gray-900">Real-time Monitoring</p>
-                        </dt>
-                        <dd class="mt-2 ml-16 text-base text-gray-500">
-                            CivicBand continuously monitors municipal websites and documents, alerting you the moment something new is published.
-                        </dd>
-                    </div>
+                        </div>
 
-                    <div class="relative">
-                        <dt>
-                            <div class="absolute flex items-center justify-center h-12 w-12 rounded-md bg-indigo-500 text-white">
-                                <svg aria-hidden="true" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 4V2a1 1 0 011-1h8a1 1 0 011 1v2m4 0H5a2 2 0 00-2 2v12a2 2 0 002 2h14a2 2 0 002-2V6a2 2 0 00-2-2z"></path>
-                                </svg>
+                        <div class="space-y-3 max-h-64 overflow-y-auto">
+                            <template x-for="result in filteredResults" :key="result.id">
+                                <div class="bg-white p-4 rounded-lg border border-gray-200 hover:border-indigo-300 transition-colors">
+                                    <div class="flex items-start justify-between">
+                                        <div class="flex-1 min-w-0">
+                                            <p class="text-sm font-medium text-gray-900" x-text="result.title"></p>
+                                            <p class="text-xs text-gray-500 mt-1">
+                                                <span x-text="result.municipality"></span> • <span x-text="result.date"></span>
+                                            </p>
+                                            <p class="text-sm text-gray-600 mt-2 line-clamp-2" x-text="result.snippet"></p>
+                                        </div>
+                                        <span class="ml-3 inline-flex items-center px-2 py-1 rounded text-xs font-medium"
+                                              :class="result.type === 'agenda' ? 'bg-blue-100 text-blue-800' : 'bg-green-100 text-green-800'"
+                                              x-text="result.type"></span>
+                                    </div>
+                                </div>
+                            </template>
+                            <div x-show="filteredResults.length === 0" class="text-center py-8 text-gray-500">
+                                <p>No results found. Try a different search term.</p>
                             </div>
-                            <p class="ml-16 text-lg leading-6 font-medium text-gray-900">Smart Filtering</p>
-                        </dt>
-                        <dd class="mt-2 ml-16 text-base text-gray-500">
-                            Set up complex filters by date, document type, municipality, or keywords to get exactly the alerts you want.
-                        </dd>
+                        </div>
                     </div>
-
-                    <div class="relative">
-                        <dt>
-                            <div class="absolute flex items-center justify-center h-12 w-12 rounded-md bg-indigo-500 text-white">
-                                <svg aria-hidden="true" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
-                                </svg>
-                            </div>
-                            <p class="ml-16 text-lg leading-6 font-medium text-gray-900">Multi-Channel Delivery</p>
-                        </dt>
-                        <dd class="mt-2 ml-16 text-base text-gray-500">
-                            Receive alerts via email, RSS, or in-app notifications. Choose your preferred delivery method for each alert type.
-                        </dd>
-                    </div>
-
-                    <div class="relative">
-                        <dt>
-                            <div class="absolute flex items-center justify-center h-12 w-12 rounded-md bg-indigo-500 text-white">
-                                <svg aria-hidden="true" class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
-                                </svg>
-                            </div>
-                            <p class="ml-16 text-lg leading-6 font-medium text-gray-900">Historical Analysis</p>
-                        </dt>
-                        <dd class="mt-2 ml-16 text-base text-gray-500">
-                            View trends and patterns in your saved searches over time. See how topics evolve across different municipalities.
-                        </dd>
-                    </div>
-                </dl>
+                </div>
             </div>
         </div>
     </div>
@@ -154,4 +119,72 @@
             </div>
         </div>
     </div>
+
+    <script>
+        function searchDemo() {
+            return {
+                query: '',
+                results: [
+                    {
+                        id: 1,
+                        title: 'City Council Regular Meeting - Budget Discussion',
+                        municipality: 'Berkeley, CA',
+                        date: 'Nov 15, 2024',
+                        type: 'agenda',
+                        snippet: 'Discussion of FY2025 budget allocations including housing assistance programs and infrastructure improvements...'
+                    },
+                    {
+                        id: 2,
+                        title: 'Planning Commission - Zoning Amendment Review',
+                        municipality: 'Oakland, CA',
+                        date: 'Nov 12, 2024',
+                        type: 'minutes',
+                        snippet: 'Review of proposed zoning changes for mixed-use development in the downtown corridor...'
+                    },
+                    {
+                        id: 3,
+                        title: 'Housing Authority Board Meeting',
+                        municipality: 'San Francisco, CA',
+                        date: 'Nov 10, 2024',
+                        type: 'agenda',
+                        snippet: 'Approval of affordable housing initiatives and tenant assistance program updates...'
+                    },
+                    {
+                        id: 4,
+                        title: 'Budget Committee - Q3 Financial Review',
+                        municipality: 'Alameda, CA',
+                        date: 'Nov 8, 2024',
+                        type: 'minutes',
+                        snippet: 'Review of third quarter expenditures and revenue projections for municipal services...'
+                    },
+                    {
+                        id: 5,
+                        title: 'City Council - Housing Policy Update',
+                        municipality: 'Fremont, CA',
+                        date: 'Nov 5, 2024',
+                        type: 'agenda',
+                        snippet: 'First reading of updated housing policy including density bonus provisions...'
+                    }
+                ],
+                filteredResults: [],
+
+                init() {
+                    this.filteredResults = this.results;
+                },
+
+                filterResults() {
+                    if (!this.query.trim()) {
+                        this.filteredResults = this.results;
+                        return;
+                    }
+                    const q = this.query.toLowerCase();
+                    this.filteredResults = this.results.filter(r =>
+                        r.title.toLowerCase().includes(q) ||
+                        r.snippet.toLowerCase().includes(q) ||
+                        r.municipality.toLowerCase().includes(q)
+                    );
+                }
+            };
+        }
+    </script>
 {% endblock content %}

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -36,9 +36,9 @@
     </div>
 
 <!-- Feature 1: Search -->
-    <div id="features" class="py-24 bg-white">
+    <div id="features" class="py-20 lg:py-32 bg-white border-t border-gray-100">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="lg:grid lg:grid-cols-2 lg:gap-16 items-center">
+            <div class="lg:grid lg:grid-cols-2 lg:gap-20 items-center">
             <!-- Text Content -->
                 <div>
                     <div class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-indigo-100 text-indigo-800 mb-4">
@@ -104,9 +104,9 @@
     </div>
 
 <!-- Feature 2: Notebooks -->
-    <div class="py-24 bg-gray-50">
+    <div class="py-20 lg:py-32 bg-gray-50 border-t border-gray-200">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="lg:grid lg:grid-cols-2 lg:gap-16 items-center">
+            <div class="lg:grid lg:grid-cols-2 lg:gap-20 items-center">
             <!-- Interactive Demo (Left side) -->
                 <div class="order-2 lg:order-1 mt-12 lg:mt-0" x-data="notebookDemo()">
                     <div class="bg-white rounded-2xl p-6 shadow-lg border border-gray-200">
@@ -179,9 +179,9 @@
     </div>
 
 <!-- Feature 3: Saved Searches -->
-    <div class="py-24 bg-white">
+    <div class="py-20 lg:py-32 bg-white border-t border-gray-100">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="lg:grid lg:grid-cols-2 lg:gap-16 items-center">
+            <div class="lg:grid lg:grid-cols-2 lg:gap-20 items-center">
             <!-- Text Content -->
                 <div>
                     <div class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-indigo-100 text-indigo-800 mb-4">
@@ -253,9 +253,9 @@
     </div>
 
 <!-- Feature 4: Notifications (Static) -->
-    <div class="py-24 bg-gray-50">
+    <div class="py-20 lg:py-32 bg-gray-50 border-t border-gray-200">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="lg:grid lg:grid-cols-2 lg:gap-16 items-center">
+            <div class="lg:grid lg:grid-cols-2 lg:gap-20 items-center">
             <!-- Static Preview (Left side) -->
                 <div class="order-2 lg:order-1 mt-12 lg:mt-0">
                     <div class="bg-white rounded-2xl p-6 shadow-lg border border-gray-200">
@@ -341,7 +341,7 @@
     </div>
 
 <!-- Final CTA -->
-    <div class="bg-indigo-600">
+    <div class="bg-indigo-600 border-t border-indigo-700">
         <div class="max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:py-24 lg:px-8 lg:flex lg:items-center lg:justify-between">
             <div>
                 <h2 class="text-3xl font-extrabold tracking-tight text-white sm:text-4xl">

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -5,101 +5,33 @@
 
 {% block content %}
 <!-- Hero Section -->
-    <div class="relative overflow-hidden bg-white">
-    <!-- Background decoration -->
-        <div class="absolute inset-y-0 h-full w-full" aria-hidden="true">
-            <div class="relative h-full">
-                <svg class="absolute right-full transform translate-y-1/3 translate-x-1/4 lg:translate-x-1/2" width="404" height="784" fill="none" viewBox="0 0 404 784">
-                    <defs>
-                        <pattern id="e229dbec-10e9-49ee-8ec3-0286ca089edf" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
-                            <rect x="0" y="0" width="4" height="4" class="text-gray-200" fill="currentColor" />
-                        </pattern>
-                    </defs>
-                    <rect width="404" height="784" fill="url(#e229dbec-10e9-49ee-8ec3-0286ca089edf)" />
-                </svg>
-                <svg class="absolute left-full transform -translate-y-3/4 -translate-x-1/4 lg:-translate-x-1/2" width="404" height="784" fill="none" viewBox="0 0 404 784">
-                    <defs>
-                        <pattern id="d2a68204-c383-44b1-b99f-42ccff4e5365" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
-                            <rect x="0" y="0" width="4" height="4" class="text-gray-200" fill="currentColor" />
-                        </pattern>
-                    </defs>
-                    <rect width="404" height="784" fill="url(#d2a68204-c383-44b1-b99f-42ccff4e5365)" />
-                </svg>
-            </div>
+    <div class="relative overflow-hidden bg-gradient-to-br from-indigo-50 to-white">
+        <div class="absolute inset-0 overflow-hidden" aria-hidden="true">
+            <div class="absolute -top-40 -right-40 w-80 h-80 bg-indigo-100 rounded-full opacity-50 blur-3xl"></div>
+            <div class="absolute -bottom-40 -left-40 w-80 h-80 bg-indigo-100 rounded-full opacity-50 blur-3xl"></div>
         </div>
 
-        <div class="relative pt-6 pb-16 sm:pb-24 lg:pb-32">
-            <main class="mt-16 mx-auto max-w-7xl px-4 sm:mt-24 sm:px-6 lg:mt-32">
-                <div class="lg:grid lg:grid-cols-12 lg:gap-8">
-                    <div class="sm:text-center md:max-w-2xl md:mx-auto lg:col-span-6 lg:text-left">
-                        <h1>
-                            <span class="block text-base font-semibold text-indigo-600 tracking-wide uppercase">CivicBand Alerting & Tracking</span>
-                            <span class="mt-1 block text-4xl tracking-tight font-extrabold sm:text-5xl xl:text-6xl">
-                                <span class="block text-gray-900">{{ title }}</span>
-                            </span>
-                        </h1>
-                        <p class="mt-3 text-base text-gray-500 sm:mt-5 sm:text-xl lg:text-lg xl:text-xl">
-                            Get instant alerts for any municipality or saved search term. {{ description }} with real-time notifications when new documents, meetings, or decisions match your interests.
-                        </p>
-                        <div class="mt-8 sm:max-w-lg sm:mx-auto sm:text-center lg:text-left lg:mx-0">
-                            <div class="mt-5 sm:mt-8 sm:flex sm:justify-center lg:justify-start">
-                                <div class="rounded-md shadow">
-                                    <a href="{% url 'munis:muni-list' %}" class="w-full flex items-center justify-center px-8 py-3 border border-transparent text-base font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 md:py-4 md:text-lg md:px-10 transition-colors duration-200">
-                                        Browse Municipalities
-                                    </a>
-                                </div>
-                                <div class="mt-3 sm:mt-0 sm:ml-3">
-                                    <a href="#features" class="w-full flex items-center justify-center px-8 py-3 border border-transparent text-base font-medium rounded-md text-indigo-700 bg-indigo-100 hover:bg-indigo-200 md:py-4 md:text-lg md:px-10 transition-colors duration-200">
-                                        Learn more
-                                    </a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="mt-12 relative sm:max-w-lg sm:mx-auto lg:mt-0 lg:max-w-none lg:mx-0 lg:col-span-6 lg:flex lg:items-center">
-                        <div class="relative mx-auto w-full rounded-lg shadow-lg lg:max-w-md">
-                        <!-- Placeholder for future dashboard screenshot -->
-                            <div class="relative block w-full bg-white rounded-lg overflow-hidden border border-gray-200">
-                                <div class="bg-gray-50 px-4 py-5 sm:p-6">
-                                    <div class="flex items-center">
-                                        <div class="flex-shrink-0">
-                                            <div class="w-8 h-8 bg-indigo-500 rounded-full flex items-center justify-center">
-                                                <svg aria-hidden="true" class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
-                                                </svg>
-                                            </div>
-                                        </div>
-                                        <div class="ml-5 w-0 flex-1">
-                                            <dl>
-                                                <dt class="text-sm font-medium text-gray-500 truncate">Active Municipalities</dt>
-                                                <dd class="text-lg font-medium text-gray-900">247</dd>
-                                            </dl>
-                                        </div>
-                                    </div>
-                                    <div class="mt-6 grid grid-cols-2 gap-4">
-                                        <div class="border border-gray-200 rounded-lg p-3">
-                                            <div class="text-xs font-medium text-gray-500">Search Alerts</div>
-                                            <div class="text-sm font-semibold text-gray-900">42</div>
-                                        </div>
-                                        <div class="border border-gray-200 rounded-lg p-3">
-                                            <div class="text-xs font-medium text-gray-500">Matching pages</div>
-                                            <div class="text-sm font-semibold text-gray-900">1,269</div>
-                                        </div>
-                                    </div>
-                                    <div class="mt-4 bg-gray-100 rounded-lg p-3">
-                                        <div class="text-xs font-medium text-gray-500 mb-2">Recent Alerts</div>
-                                        <div class="space-y-1">
-                                            <div class="text-xs text-gray-600">🔔 "Budget" search: 3 new documents</div>
-                                            <div class="text-xs text-gray-600">🔔 Berkeley City: Council meeting tonight</div>
-                                            <div class="text-xs text-gray-600">🔔 "Housing" search: Policy change</div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+        <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24 sm:py-32">
+            <div class="text-center max-w-3xl mx-auto">
+                <h1 class="text-4xl sm:text-5xl lg:text-6xl font-extrabold text-gray-900 tracking-tight">
+                    Stay informed about<br>
+                    <span class="text-indigo-600">local government</span>
+                </h1>
+                <p class="mt-6 text-xl text-gray-600 max-w-2xl mx-auto">
+                    Search meeting agendas and minutes, save important pages, and get notified when topics you care about come up in your community.
+                </p>
+                <div class="mt-10 flex flex-col sm:flex-row gap-4 justify-center">
+                    <a href="{% url 'stagedoor:auth' %}" class="inline-flex items-center justify-center px-8 py-4 border border-transparent text-lg font-medium rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 shadow-lg hover:shadow-xl transition-all duration-200">
+                        Get Started Free
+                        <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
+                        </svg>
+                    </a>
+                    <a href="#features" class="inline-flex items-center justify-center px-8 py-4 border border-gray-300 text-lg font-medium rounded-lg text-gray-700 bg-white hover:bg-gray-50 shadow hover:shadow-md transition-all duration-200">
+                        See how it works
+                    </a>
                 </div>
-            </main>
+            </div>
         </div>
     </div>
 

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -178,6 +178,80 @@
         </div>
     </div>
 
+<!-- Feature 3: Saved Searches -->
+    <div class="py-24 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="lg:grid lg:grid-cols-2 lg:gap-16 items-center">
+            <!-- Text Content -->
+                <div>
+                    <div class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-indigo-100 text-indigo-800 mb-4">
+                        <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"></path>
+                        </svg>
+                        Saved Searches
+                    </div>
+                    <h2 class="text-3xl font-bold text-gray-900 sm:text-4xl">
+                        Never miss an important topic
+                    </h2>
+                    <p class="mt-4 text-lg text-gray-600">
+                        Save your search criteria and we'll monitor new meeting documents for you. Get notified the moment something relevant is published.
+                    </p>
+                    <div class="mt-8">
+                        <a href="{% url 'searches:savedsearch-list' %}" class="inline-flex items-center text-indigo-600 font-medium hover:text-indigo-700">
+                            Set up your first saved search
+                            <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
+                            </svg>
+                        </a>
+                    </div>
+                </div>
+
+            <!-- Interactive Demo -->
+                <div class="mt-12 lg:mt-0" x-data="savedSearchDemo()">
+                    <div class="bg-gray-50 rounded-2xl p-6 shadow-lg border border-gray-200">
+                        <h3 class="font-semibold text-gray-900 mb-4">Your Saved Searches</h3>
+
+                        <div class="space-y-3">
+                            <template x-for="search in searches" :key="search.id">
+                                <div class="bg-white p-4 rounded-lg border border-gray-200">
+                                    <div class="flex items-center justify-between">
+                                        <div>
+                                            <p class="font-medium text-gray-900" x-text="search.name"></p>
+                                            <p class="text-sm text-gray-500 mt-1">
+                                                <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-indigo-100 text-indigo-800" x-text="'\"' + search.term + '\"'"></span>
+                                                <span class="ml-2" x-text="search.scope"></span>
+                                            </p>
+                                        </div>
+                                        <div class="flex items-center gap-2">
+                                            <span x-show="search.newResults > 0"
+                                                  class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800">
+                                                <span x-text="search.newResults"></span> new
+                                            </span>
+                                            <span class="inline-flex items-center px-2 py-1 rounded text-xs font-medium"
+                                                  :class="search.frequency === 'immediate' ? 'bg-red-100 text-red-800' : search.frequency === 'daily' ? 'bg-blue-100 text-blue-800' : 'bg-green-100 text-green-800'"
+                                                  x-text="search.frequency"></span>
+                                        </div>
+                                    </div>
+                                </div>
+                            </template>
+                        </div>
+
+                        <div class="mt-4 p-4 bg-indigo-50 rounded-lg border border-indigo-100">
+                            <div class="flex items-start">
+                                <svg class="w-5 h-5 text-indigo-600 mt-0.5 mr-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                                </svg>
+                                <p class="text-sm text-indigo-800">
+                                    <strong>Tip:</strong> Use "immediate" for time-sensitive topics and "weekly" for general monitoring.
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
 <!-- CTA Section -->
     <div class="bg-indigo-50">
         <div class="max-w-7xl mx-auto py-12 px-4 sm:px-6 lg:py-16 lg:px-8 lg:flex lg:items-center lg:justify-between">
@@ -303,6 +377,37 @@
                         ...page
                     });
                 }
+            };
+        }
+
+        function savedSearchDemo() {
+            return {
+                searches: [
+                    {
+                        id: 1,
+                        name: 'Housing Policy Updates',
+                        term: 'affordable housing',
+                        scope: '3 municipalities',
+                        frequency: 'immediate',
+                        newResults: 2
+                    },
+                    {
+                        id: 2,
+                        name: 'Budget Discussions',
+                        term: 'budget',
+                        scope: 'All Bay Area',
+                        frequency: 'daily',
+                        newResults: 5
+                    },
+                    {
+                        id: 3,
+                        name: 'Zoning Changes',
+                        term: 'zoning amendment',
+                        scope: 'Oakland, CA',
+                        frequency: 'weekly',
+                        newResults: 0
+                    }
+                ]
             };
         }
     </script>

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -21,7 +21,7 @@
                     Search meeting agendas and minutes, save important pages, and get notified when topics you care about come up in your community.
                 </p>
                 <div class="mt-10 flex flex-col sm:flex-row gap-4 justify-center">
-                    <a href="{% url 'stagedoor:auth' %}" class="inline-flex items-center justify-center px-8 py-4 border border-transparent text-lg font-medium rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 shadow-lg hover:shadow-xl transition-all duration-200">
+                    <a href="{% url 'stagedoor:login' %}" class="inline-flex items-center justify-center px-8 py-4 border border-transparent text-lg font-medium rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 shadow-lg hover:shadow-xl transition-all duration-200">
                         Get Started Free
                         <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
@@ -352,7 +352,7 @@
                 </p>
             </div>
             <div class="mt-8 flex flex-col sm:flex-row gap-4 lg:mt-0 lg:flex-shrink-0">
-                <a href="{% url 'stagedoor:auth' %}" class="inline-flex items-center justify-center px-6 py-4 border border-transparent text-lg font-medium rounded-lg text-indigo-600 bg-white hover:bg-indigo-50 shadow-lg transition-all duration-200">
+                <a href="{% url 'stagedoor:login' %}" class="inline-flex items-center justify-center px-6 py-4 border border-transparent text-lg font-medium rounded-lg text-indigo-600 bg-white hover:bg-indigo-50 shadow-lg transition-all duration-200">
                     Get Started Free
                 </a>
                 <a href="{% url 'meetings:meeting-search' %}" class="inline-flex items-center justify-center px-6 py-4 border-2 border-white text-lg font-medium rounded-lg text-white hover:bg-indigo-500 transition-all duration-200">

--- a/templates/meetings/partials/search_results.html
+++ b/templates/meetings/partials/search_results.html
@@ -1,4 +1,4 @@
-{% load meeting_filters notebook_filters %}
+{% load meeting_filters notebook_filters utm %}
 
 {% if error %}
     <!-- Error State -->
@@ -125,7 +125,7 @@
                 <!-- Actions -->
                 <div class="mt-4 flex items-center justify-between pt-4 border-t border-gray-200">
                     <div class="flex items-center space-x-2">
-                        <a href="https://{{ result.document.municipality.subdomain }}.civic.band/meetings/{{ result.document.civic_band_table_name }}/{{ result.id }}"
+                        <a href="{% civic_url 'https://'|add:result.document.municipality.subdomain|add:'.civic.band/meetings/'|add:result.document.civic_band_table_name|add:'/'|add:result.id medium='search' campaign='search_results' content='view_button' %}"
                            target="_blank"
                            rel="noopener noreferrer"
                            aria-label="View {{ result.document.meeting_name }} {{ result.document.document_type }} from {{ result.document.meeting_date|date:'F d, Y' }} on CivicBand (opens in new window)"

--- a/templates/notebooks/notebook_detail.html
+++ b/templates/notebooks/notebook_detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load utm %}
 
 {% block title %}{{ notebook.name }} - CivicObserver{% endblock %}
 
@@ -99,7 +100,7 @@
 
                     <!-- View on CivicBand link -->
                         <div class="mt-4 pt-3 border-t border-gray-200">
-                            <a href="https://{{ entry.meeting_page.document.municipality.subdomain }}.civic.band/meetings/{{ entry.meeting_page.document.civic_band_table_name }}/{{ entry.meeting_page.id }}"
+                            <a href="{% civic_url 'https://'|add:entry.meeting_page.document.municipality.subdomain|add:'.civic.band/meetings/'|add:entry.meeting_page.document.civic_band_table_name|add:'/'|add:entry.meeting_page.id medium='notebook' campaign='notebook_detail' content='view_button' %}"
                                target="_blank"
                                rel="noopener noreferrer"
                                class="text-sm text-indigo-600 hover:text-indigo-800">

--- a/tests/analytics/test_utm.py
+++ b/tests/analytics/test_utm.py
@@ -1,0 +1,103 @@
+from django.template import Context, Template
+
+
+class TestCivicUrlTag:
+    def test_adds_utm_params_to_civic_band_url(self):
+        """civic_url tag adds UTM parameters to civic.band URLs."""
+        template = Template(
+            "{% load utm %}"
+            '{% civic_url "https://alameda.ca.civic.band/meetings/agendas/123" '
+            'medium="search" campaign="search_results" content="view_button" %}'
+        )
+        result = template.render(Context({}))
+
+        assert "utm_source=civicobserver" in result
+        assert "utm_medium=search" in result
+        assert "utm_campaign=search_results" in result
+        assert "utm_content=view_button" in result
+        assert result.startswith("https://alameda.ca.civic.band/meetings/agendas/123?")
+
+    def test_adds_utm_params_to_docs_civic_band(self):
+        """civic_url tag adds UTM parameters to docs.civic.band URLs."""
+        template = Template(
+            "{% load utm %}"
+            '{% civic_url "https://docs.civic.band/api/reference" '
+            'medium="nav" campaign="footer" content="docs_link" %}'
+        )
+        result = template.render(Context({}))
+
+        assert "utm_source=civicobserver" in result
+        assert "utm_medium=nav" in result
+        assert "utm_campaign=footer" in result
+        assert "utm_content=docs_link" in result
+
+    def test_non_civic_url_unchanged(self):
+        """civic_url tag returns non-civic URLs unchanged."""
+        template = Template(
+            "{% load utm %}"
+            '{% civic_url "https://google.com/search" '
+            'medium="search" campaign="search_results" %}'
+        )
+        result = template.render(Context({}))
+
+        assert result == "https://google.com/search"
+        assert "utm_" not in result
+
+    def test_fake_civic_domain_unchanged(self):
+        """civic_url tag doesn't add UTM to domains that look like civic.band but aren't."""
+        template = Template(
+            "{% load utm %}"
+            '{% civic_url "https://civic.band.fake.com/page" '
+            'medium="search" campaign="test" %}'
+        )
+        result = template.render(Context({}))
+
+        assert result == "https://civic.band.fake.com/page"
+        assert "utm_" not in result
+
+    def test_preserves_existing_query_params(self):
+        """civic_url tag preserves existing query parameters."""
+        template = Template(
+            "{% load utm %}"
+            '{% civic_url "https://civic.band/page?foo=bar&baz=qux" '
+            'medium="search" campaign="test" %}'
+        )
+        result = template.render(Context({}))
+
+        assert "foo=bar" in result
+        assert "baz=qux" in result
+        assert "utm_source=civicobserver" in result
+
+    def test_empty_url_returns_empty(self):
+        """civic_url tag returns empty string for empty URL."""
+        template = Template(
+            '{% load utm %}{% civic_url "" medium="search" campaign="test" %}'
+        )
+        result = template.render(Context({}))
+
+        assert result == ""
+
+    def test_default_content_value(self):
+        """civic_url tag uses 'link' as default content value."""
+        template = Template(
+            "{% load utm %}"
+            '{% civic_url "https://civic.band/page" '
+            'medium="search" campaign="test" %}'
+        )
+        result = template.render(Context({}))
+
+        assert "utm_content=link" in result
+
+    def test_url_from_template_variable(self):
+        """civic_url tag works with URLs from template variables."""
+        template = Template(
+            "{% load utm %}"
+            '{% civic_url page_url medium="notebook" campaign="notebook_detail" %}'
+        )
+        result = template.render(
+            Context({"page_url": "https://oakland.ca.civic.band/meetings/minutes/456"})
+        )
+
+        assert "utm_source=civicobserver" in result
+        assert "utm_medium=notebook" in result
+        assert "utm_campaign=notebook_detail" in result


### PR DESCRIPTION
## Summary

- Add `{% civic_url %}` Django template tag for adding UTM parameters to civic.band and docs.civic.band URLs
- Update all outbound civic.band links across templates with UTM tracking:
  - Search results "View on CivicBand" button
  - Notebook detail "View on CivicBand" links
  - Clip templates (preview, error, cancel links)
  - Footer links (CivicBand, Terms, Privacy)
  - Email notification links

## UTM Parameters

| Parameter | Value |
|-----------|-------|
| utm_source | civicobserver |
| utm_medium | search / notebook / clip / email / nav |
| utm_campaign | search_results / notebook_detail / clip_preview / footer / search_update |
| utm_content | view_button / return_link / cancel_button / etc. |

## Test Plan

- [x] 8 unit tests for template tag (domain validation, query param preservation, edge cases)
- [x] All 417 tests pass
- [x] 84% code coverage
- [x] Ruff and mypy pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)