### PR TITLE
fix(auth): use correct login URL to prevent 405 errors

### DIFF
--- a/templates/api.html
+++ b/templates/api.html
@@ -128,7 +128,7 @@
                         <div>
                             <h3 class="text-lg font-semibold text-gray-900">Create an account</h3>
                             <p class="mt-2 text-gray-600">Sign up for free to get access to the API. No credit card required.</p>
-                            <a href="{% url 'stagedoor:login' %}" class="mt-3 inline-flex items-center text-indigo-600 font-medium hover:text-indigo-700">
+                            <a href="{% url 'login' %}" class="mt-3 inline-flex items-center text-indigo-600 font-medium hover:text-indigo-700">
                                 Sign up now
                                 <svg class="ml-1 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
@@ -188,7 +188,7 @@
                 Create a free account and start exploring the API today.
             </p>
             <div class="mt-8 flex flex-col sm:flex-row gap-4 justify-center">
-                <a href="{% url 'stagedoor:login' %}" class="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-lg text-indigo-600 bg-white hover:bg-gray-100 transition-colors">
+                <a href="{% url 'login' %}" class="inline-flex items-center justify-center px-6 py-3 border border-transparent text-base font-medium rounded-lg text-indigo-600 bg-white hover:bg-gray-100 transition-colors">
                     Create Free Account
                 </a>
                 <a href="https://docs.civic.band" target="_blank" rel="noopener" class="inline-flex items-center justify-center px-6 py-3 border-2 border-white text-base font-medium rounded-lg text-white hover:bg-indigo-500 transition-colors">

--- a/templates/homepage.html
+++ b/templates/homepage.html
@@ -21,7 +21,7 @@
                     Search meeting agendas and minutes, save important pages, and get notified when topics you care about come up in your community.
                 </p>
                 <div class="mt-10 flex flex-col sm:flex-row gap-4 justify-center">
-                    <a href="{% url 'stagedoor:login' %}" class="inline-flex items-center justify-center px-8 py-4 border border-transparent text-lg font-medium rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 shadow-lg hover:shadow-xl transition-all duration-200">
+                    <a href="{% url 'login' %}" class="inline-flex items-center justify-center px-8 py-4 border border-transparent text-lg font-medium rounded-lg text-white bg-indigo-600 hover:bg-indigo-700 shadow-lg hover:shadow-xl transition-all duration-200">
                         Get Started Free
                         <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 7l5 5m0 0l-5 5m5-5H6"></path>
@@ -352,7 +352,7 @@
                 </p>
             </div>
             <div class="mt-8 flex flex-col sm:flex-row gap-4 lg:mt-0 lg:flex-shrink-0">
-                <a href="{% url 'stagedoor:login' %}" class="inline-flex items-center justify-center px-6 py-4 border border-transparent text-lg font-medium rounded-lg text-indigo-600 bg-white hover:bg-indigo-50 shadow-lg transition-all duration-200">
+                <a href="{% url 'login' %}" class="inline-flex items-center justify-center px-6 py-4 border border-transparent text-lg font-medium rounded-lg text-indigo-600 bg-white hover:bg-indigo-50 shadow-lg transition-all duration-200">
                     Get Started Free
                 </a>
                 <a href="{% url 'meetings:meeting-search' %}" class="inline-flex items-center justify-center px-6 py-4 border-2 border-white text-lg font-medium rounded-lg text-white hover:bg-indigo-500 transition-all duration-200">

--- a/tests/users/test_views.py
+++ b/tests/users/test_views.py
@@ -1,0 +1,34 @@
+"""Tests for user views including login page."""
+
+import pytest
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+class TestLoginView:
+    """Tests for the login view."""
+
+    def test_login_page_returns_200_for_get(self, client):
+        """
+        Test that GET /login/ returns 200.
+
+        This is a regression test to ensure the login page is accessible.
+        Previously, links incorrectly pointed to stagedoor:login (POST-only),
+        causing 405 errors when users clicked login links.
+        """
+        response = client.get(reverse("login"))
+        assert response.status_code == 200
+
+    def test_login_page_renders_form(self, client):
+        """Test that the login page renders a form with email field."""
+        response = client.get(reverse("login"))
+        assert response.status_code == 200
+        assert b"email" in response.content.lower()
+        assert b"login" in response.content.lower()
+
+    def test_login_form_posts_to_auth_login(self, client):
+        """Test that the login form posts to /auth/login."""
+        response = client.get(reverse("login"))
+        assert response.status_code == 200
+        # The form should post to /auth/login
+        assert b'action="/auth/login"' in response.content


### PR DESCRIPTION
## Summary

- Fixed 405 errors when clicking "Get Started" and "Sign up" links on homepage and API pages
- Links were incorrectly pointing to `stagedoor:login` (`/auth/login`) which is POST-only
- Changed to use `login` URL (`/login/`) which renders the login form

## Root Cause

The `stagedoor:login` URL maps to a view decorated with `@require_http_methods(["POST"])`. When users clicked links, browsers sent GET requests, resulting in 405 Method Not Allowed errors.

## Changes

- `templates/homepage.html`: 2 links updated
- `templates/api.html`: 2 links updated  
- `tests/users/test_views.py`: Added regression tests

## Test plan

- [x] Verify `/login/` returns 200 for GET requests
- [x] Verify login form renders with email field
- [x] Verify form posts to `/auth/login`
- [ ] Manual test: Click "Get Started" on homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)