### PR TITLE
feat(docker): run containers as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,17 @@
 # ------------------------------------------------------------
-# Base/builder layer
+# Stage 1: Builder - Install dependencies
 # ------------------------------------------------------------
 
 FROM python:3.13-slim-bookworm AS builder
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV PYTHONPATH=/srv
 ENV PYTHONUNBUFFERED=1
 
 COPY pyproject.toml /tmp/pyproject.toml
 
-# add ",sharing=locked" if release should block until builder is complete
 RUN --mount=type=cache,target=/root/.cache,sharing=locked,id=pip \
-    python -m pip install --upgrade pip uv just-bin
+    python -m pip install --upgrade pip uv
 
 RUN --mount=type=cache,target=/root/.cache,sharing=locked,id=pip \
     python -m uv pip compile /tmp/pyproject.toml -o /tmp/requirements.txt
@@ -22,17 +20,59 @@ RUN --mount=type=cache,target=/root/.cache,sharing=locked,id=pip \
     python -m uv pip install --system --requirement /tmp/requirements.txt
 
 # ------------------------------------------------------------
-# Dev/testing layer
+# Stage 2: Asset Builder - Build static assets
 # ------------------------------------------------------------
 
-FROM builder AS release
+FROM builder AS asset-builder
+
+# Install Node.js for Tailwind
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY . /src/
+WORKDIR /src/
+
+# Build Tailwind CSS and collect static files
+RUN python manage.py tailwind build
+RUN python manage.py collectstatic --noinput --skip-checks
+
+# ------------------------------------------------------------
+# Stage 3: Release - Final production image
+# ------------------------------------------------------------
+
+FROM python:3.13-slim-bookworm AS release
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONPATH=/src
+ENV PYTHONUNBUFFERED=1
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user with UID/GID 1000
+RUN groupadd --gid 1000 app && \
+    useradd --uid 1000 --gid 1000 --create-home --shell /bin/bash app
+
+# Copy Python packages from builder
+COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
+
+# Copy application code
+COPY --chown=app:app . /src/
+
+# Copy pre-built static files from asset-builder
+COPY --from=asset-builder --chown=app:app /src/staticfiles /src/staticfiles
+COPY --from=asset-builder --chown=app:app /src/theme/static /src/theme/static
 
 WORKDIR /src/
 
-CMD ["uvicorn", "config.asgi:application", "--host", "0.0.0.0", "--limit-max-requests", "100", "--timeout-graceful-shutdown", "7"]
+# Switch to non-root user
+USER app
 
-# ------------------------------------------------------------
-# TODO: Add Production notes
-# ------------------------------------------------------------
+CMD ["uvicorn", "config.asgi:application", "--host", "0.0.0.0", "--limit-max-requests", "100", "--timeout-graceful-shutdown", "7"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,8 +67,8 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --chown=app:app . /src/
 
 # Copy pre-built static files from asset-builder
-COPY --from=asset-builder --chown=app:app /src/staticfiles /src/staticfiles
-COPY --from=asset-builder --chown=app:app /src/theme/static /src/theme/static
+COPY --from=asset-builder --chown=app:app /src/static /src/static
+COPY --from=asset-builder --chown=app:app /src/frontend/css /src/frontend/css
 
 WORKDIR /src/
 

--- a/compose-entrypoint.sh
+++ b/compose-entrypoint.sh
@@ -1,10 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-python manage.py tailwind build
-
 python manage.py migrate --noinput --skip-checks
-
-python manage.py collectstatic --noinput --skip-checks
 
 exec "$@"

--- a/docs/plans/2025-12-19-non-root-docker-design.md
+++ b/docs/plans/2025-12-19-non-root-docker-design.md
@@ -1,0 +1,183 @@
+# Non-Root Docker Container Design
+
+## Overview
+
+Configure Docker containers to run as a non-root user (`app` with UID 1000) for improved security. This applies to both development and production environments.
+
+## Goals
+
+- Run Django application containers as non-root user
+- Build static assets at image build time (not runtime)
+- Maintain seamless development experience with volume mounts
+- Keep production images self-contained and immutable
+
+## Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Environments | Both dev and prod | Consistency prevents deployment surprises |
+| Static assets | Build at image time | Faster startup, immutable images |
+| User UID | 1000 | Matches default Linux user, Docker Desktop handles mapping |
+| User name | `app` | Simple, generic, framework-agnostic |
+| Image strategy | Single image with static files | Self-contained, reproducible deployments |
+
+## Dockerfile Changes
+
+Restructure into three stages:
+
+### Stage 1: Builder (unchanged concept)
+- Install `uv`, compile and install Python dependencies
+- Runs as root (fine for build-time)
+
+### Stage 2: Asset Builder (new)
+- Copy source code
+- Run `tailwind build` and `collectstatic`
+- Output compiled static files to known location
+
+### Stage 3: Release
+- Create `app` user with UID/GID 1000
+- Copy Python packages from builder stage
+- Copy pre-built static files from asset-builder stage
+- Set ownership of `/src` to `app:app`
+- Set `USER app` before `CMD`
+
+```dockerfile
+# Example structure (not complete):
+
+FROM python:3.13-slim-bookworm AS builder
+# ... install dependencies ...
+
+FROM builder AS asset-builder
+COPY . /src/
+WORKDIR /src/
+RUN python manage.py tailwind build
+RUN python manage.py collectstatic --noinput
+
+FROM python:3.13-slim-bookworm AS release
+# Create non-root user
+RUN groupadd --gid 1000 app && \
+    useradd --uid 1000 --gid 1000 --create-home app
+
+# Copy dependencies from builder
+COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
+
+# Copy application code and static files
+COPY --chown=app:app . /src/
+COPY --from=asset-builder --chown=app:app /src/staticfiles /src/staticfiles
+
+WORKDIR /src/
+USER app
+
+CMD ["uvicorn", "config.asgi:application", "--host", "0.0.0.0"]
+```
+
+## Entrypoint Script Changes
+
+Current entrypoint does three things:
+1. `tailwind build` — **moves to Dockerfile**
+2. `collectstatic` — **moves to Dockerfile**
+3. `migrate` — **stays in entrypoint**
+
+New `compose-entrypoint.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -eo pipefail
+
+python manage.py migrate --noinput --skip-checks
+
+exec "$@"
+```
+
+Migrations can run as `app` user — they only need database access, not filesystem write access.
+
+## Docker Compose Changes
+
+### Development (`docker-compose.yml`)
+
+Minimal changes required:
+
+- Volume mount `.:/src:cache` stays the same (UID 1000 matches typical host users)
+- No `user:` directive needed (Dockerfile handles it)
+- Third-party images unchanged (postgres, redis, pgbouncer manage their own users)
+
+### Production (`docker-compose.blue.yml`, `docker-compose.green.yml`)
+
+No changes needed:
+
+- Image runs as non-root via Dockerfile
+- Entrypoint still runs migrations before starting services
+- Static files baked into image, served by whitenoise/reverse proxy
+
+## Third-Party Images
+
+These already handle non-root appropriately:
+
+| Image | User | Notes |
+|-------|------|-------|
+| `postgres:17-alpine` | `postgres` | Dev only, runs as postgres user |
+| `redis:7-alpine` | `redis` | Runs as redis user |
+| `edoburu/pgbouncer` | configured | Manages its own user |
+
+## Testing & Verification
+
+After implementing, verify with:
+
+```bash
+# Check container runs as non-root
+docker-compose run --rm utility whoami
+# Expected: app
+
+docker-compose run --rm utility id
+# Expected: uid=1000(app) gid=1000(app) groups=1000(app)
+
+# Verify static files are present
+docker-compose run --rm utility ls -la staticfiles/
+
+# Verify migrations can run
+docker-compose run --rm utility python manage.py migrate --check
+```
+
+## Potential Issues
+
+1. **Host UID mismatch**: If your host user isn't UID 1000, new files created by the container may have different ownership. Rare on standard setups.
+
+2. **Unexpected write locations**: Code attempting to write outside `/src` will fail with permission errors. This is a feature — it surfaces hidden assumptions.
+
+3. **Third-party packages**: Packages expecting system path write access will fail. Rare, but watch for it.
+
+## Security Benefits
+
+- Container compromise gives attacker limited privileges
+- No root access to escape to host or modify system files
+- Follows principle of least privilege
+- Aligns with container security best practices (CIS Docker Benchmark)
+
+## Files to Modify
+
+1. `Dockerfile` — Restructure stages, add user creation
+2. `compose-entrypoint.sh` — Remove tailwind/collectstatic commands
+3. No changes needed to docker-compose files
+
+## Out of Scope
+
+- Modifying third-party images (postgres, redis, pgbouncer)
+- Rootless Docker daemon configuration
+- Kubernetes-specific security contexts
+
+## Implementation Notes
+
+**Completed:** 2025-12-19
+
+**Changes from design:**
+- Static file path is `/src/static` (not `/src/staticfiles`) to match `STATIC_ROOT` in Django settings
+- Tailwind CSS outputs to `/src/frontend/css/tailwind.css`, copied separately from static files
+- No `theme/static` directory exists in this project; removed from Dockerfile
+
+**Verification results:**
+- Container runs as `app` user (UID 1000, GID 1000)
+- Static files built at image time and present in container
+- Tailwind CSS (92KB) built and available at `/src/frontend/css/tailwind.css`
+- Django check passes
+- Migrations run successfully as non-root
+- All 417 tests pass (83.9% coverage)

--- a/docs/plans/2025-12-19-non-root-docker-implementation.md
+++ b/docs/plans/2025-12-19-non-root-docker-implementation.md
@@ -1,0 +1,356 @@
+# Non-Root Docker Container Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Configure Docker containers to run as non-root user (`app` with UID 1000) for improved security.
+
+**Architecture:** Restructure Dockerfile into builder, asset-builder, and release stages. Build static assets at image time. Create `app` user in final stage with UID/GID 1000.
+
+**Tech Stack:** Docker, Docker Compose, Django, Tailwind CSS
+
+---
+
+## Task 1: Restructure Dockerfile with Non-Root User
+
+**Files:**
+- Modify: `Dockerfile`
+
+**Step 1: Read current Dockerfile**
+
+Read the existing Dockerfile to understand current structure.
+
+**Step 2: Rewrite Dockerfile with three stages**
+
+Replace entire Dockerfile content with:
+
+```dockerfile
+# ------------------------------------------------------------
+# Stage 1: Builder - Install dependencies
+# ------------------------------------------------------------
+
+FROM python:3.13-slim-bookworm AS builder
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+COPY pyproject.toml /tmp/pyproject.toml
+
+RUN --mount=type=cache,target=/root/.cache,sharing=locked,id=pip \
+    python -m pip install --upgrade pip uv
+
+RUN --mount=type=cache,target=/root/.cache,sharing=locked,id=pip \
+    python -m uv pip compile /tmp/pyproject.toml -o /tmp/requirements.txt
+
+RUN --mount=type=cache,target=/root/.cache,sharing=locked,id=pip \
+    python -m uv pip install --system --requirement /tmp/requirements.txt
+
+# ------------------------------------------------------------
+# Stage 2: Asset Builder - Build static assets
+# ------------------------------------------------------------
+
+FROM builder AS asset-builder
+
+# Install Node.js for Tailwind
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY . /src/
+WORKDIR /src/
+
+# Build Tailwind CSS and collect static files
+RUN python manage.py tailwind build
+RUN python manage.py collectstatic --noinput --skip-checks
+
+# ------------------------------------------------------------
+# Stage 3: Release - Final production image
+# ------------------------------------------------------------
+
+FROM python:3.13-slim-bookworm AS release
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONPATH=/src
+ENV PYTHONUNBUFFERED=1
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user with UID/GID 1000
+RUN groupadd --gid 1000 app && \
+    useradd --uid 1000 --gid 1000 --create-home --shell /bin/bash app
+
+# Copy Python packages from builder
+COPY --from=builder /usr/local/lib/python3.13/site-packages /usr/local/lib/python3.13/site-packages
+COPY --from=builder /usr/local/bin /usr/local/bin
+
+# Copy application code
+COPY --chown=app:app . /src/
+
+# Copy pre-built static files from asset-builder
+COPY --from=asset-builder --chown=app:app /src/staticfiles /src/staticfiles
+COPY --from=asset-builder --chown=app:app /src/theme/static /src/theme/static
+
+WORKDIR /src/
+
+# Switch to non-root user
+USER app
+
+CMD ["uvicorn", "config.asgi:application", "--host", "0.0.0.0", "--limit-max-requests", "100", "--timeout-graceful-shutdown", "7"]
+```
+
+**Step 3: Commit Dockerfile changes**
+
+```bash
+git add Dockerfile
+git commit -m "feat(docker): restructure Dockerfile for non-root execution
+
+- Add three-stage build: builder, asset-builder, release
+- Create app user with UID/GID 1000
+- Build Tailwind and collectstatic at image build time
+- Run final container as non-root user"
+```
+
+---
+
+## Task 2: Update Entrypoint Script
+
+**Files:**
+- Modify: `compose-entrypoint.sh`
+
+**Step 1: Read current entrypoint**
+
+Read the existing compose-entrypoint.sh to understand what it does.
+
+**Step 2: Remove static asset commands from entrypoint**
+
+Replace entire file content with:
+
+```bash
+#!/usr/bin/env bash
+set -eo pipefail
+
+python manage.py migrate --noinput --skip-checks
+
+exec "$@"
+```
+
+**Step 3: Commit entrypoint changes**
+
+```bash
+git add compose-entrypoint.sh
+git commit -m "refactor(docker): simplify entrypoint to migrations only
+
+Static asset building (tailwind, collectstatic) now happens at
+image build time in the Dockerfile."
+```
+
+---
+
+## Task 3: Build and Verify Development Image
+
+**Files:**
+- None (verification only)
+
+**Step 1: Build the Docker image**
+
+```bash
+docker-compose build web
+```
+
+Expected: Build completes successfully with all three stages.
+
+**Step 2: Verify container runs as non-root**
+
+```bash
+docker-compose run --rm utility whoami
+```
+
+Expected output: `app`
+
+**Step 3: Verify user ID is 1000**
+
+```bash
+docker-compose run --rm utility id
+```
+
+Expected output: `uid=1000(app) gid=1000(app) groups=1000(app)`
+
+**Step 4: Verify static files are present**
+
+```bash
+docker-compose run --rm utility ls -la staticfiles/ | head -10
+```
+
+Expected: Directory listing showing static files owned by app:app.
+
+**Step 5: Verify Django can start**
+
+```bash
+docker-compose up web -d
+sleep 5
+curl -s http://localhost:${DJANGO_PORT:-8000}/health/ || echo "Check DJANGO_PORT in .env"
+docker-compose stop web
+```
+
+Expected: Health check returns success or 200 response.
+
+---
+
+## Task 4: Verify Worker Container
+
+**Files:**
+- None (verification only)
+
+**Step 1: Verify worker runs as non-root**
+
+```bash
+docker-compose run --rm worker whoami
+```
+
+Expected output: `app`
+
+**Step 2: Verify worker can start**
+
+```bash
+docker-compose up worker -d
+sleep 3
+docker-compose logs worker --tail 10
+docker-compose stop worker
+```
+
+Expected: Worker starts without permission errors.
+
+---
+
+## Task 5: Test Migration Capability
+
+**Files:**
+- None (verification only)
+
+**Step 1: Verify migrations can run as non-root**
+
+```bash
+docker-compose run --rm utility python manage.py migrate --check
+```
+
+Expected: "No migrations to apply" or successful migration check.
+
+**Step 2: Verify makemigrations works (development)**
+
+```bash
+docker-compose run --rm utility python manage.py makemigrations --dry-run
+```
+
+Expected: Command runs without permission errors (may show "No changes detected").
+
+---
+
+## Task 6: Run Full Test Suite
+
+**Files:**
+- None (verification only)
+
+**Step 1: Run pytest to ensure nothing broke**
+
+```bash
+uv run pytest -q
+```
+
+Expected: All tests pass (417 passed as baseline).
+
+**Step 2: Commit verification notes (optional)**
+
+If any adjustments were needed during verification, commit them now.
+
+---
+
+## Task 7: Update Design Document with Implementation Notes
+
+**Files:**
+- Modify: `docs/plans/2025-12-19-non-root-docker-design.md`
+
+**Step 1: Add implementation notes to design doc**
+
+Append to the design document:
+
+```markdown
+
+## Implementation Notes
+
+**Completed:** 2025-12-19
+
+**Changes from design:**
+- [Note any deviations from original design]
+
+**Verification results:**
+- Container runs as `app` user (UID 1000)
+- Static files built at image time
+- Migrations run successfully as non-root
+- All 417 tests pass
+```
+
+**Step 2: Commit documentation update**
+
+```bash
+git add docs/plans/2025-12-19-non-root-docker-design.md
+git commit -m "docs: add implementation notes to non-root docker design"
+```
+
+---
+
+## Task 8: Final Cleanup and Summary
+
+**Step 1: Review all commits**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Verify commits are clean and well-described.
+
+**Step 2: Run final verification**
+
+```bash
+docker-compose down
+docker-compose up -d db redis
+docker-compose build
+docker-compose run --rm utility whoami
+docker-compose run --rm utility python manage.py check
+```
+
+Expected: All commands succeed, whoami shows `app`.
+
+**Step 3: Report completion**
+
+Feature complete. Ready for PR or merge.
+
+---
+
+## Troubleshooting
+
+### Permission denied errors
+
+If you see permission errors when writing files:
+1. Check that source volume mount is correct: `.:/src:cache`
+2. Verify your host user UID: `id -u` (should be 1000)
+3. If UID mismatch, may need to `chown -R $(id -u):$(id -g) .` on host
+
+### Static files missing
+
+If staticfiles directory is empty:
+1. Check asset-builder stage logs during `docker-compose build`
+2. Verify `STATIC_ROOT` setting in Django settings
+3. Ensure `theme/static` path exists in source
+
+### Tailwind build fails
+
+If Tailwind build fails during image build:
+1. Check Node.js installation in asset-builder stage
+2. Verify `theme/` directory structure
+3. Check for missing npm dependencies (may need to add npm install step)


### PR DESCRIPTION
## Summary

- Restructure Dockerfile into 3 stages: builder, asset-builder, release
- Create `app` user (UID/GID 1000) for container execution
- Build Tailwind CSS and collectstatic at image build time (not runtime)
- Simplify entrypoint to only run migrations

## Security Benefits

- Containers run as non-root, limiting blast radius of potential compromise
- Follows CIS Docker Benchmark recommendations
- Immutable static assets prevent runtime tampering

## Test Plan

- [x] Container runs as `app` user (`whoami` returns `app`)
- [x] User ID is 1000 (`id` shows `uid=1000(app) gid=1000(app)`)
- [x] Static files present in container at `/src/static/`
- [x] Tailwind CSS built at `/src/frontend/css/tailwind.css`
- [x] Django check passes
- [x] Migrations run successfully as non-root
- [x] All 417 tests pass (83.9% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)