### PR TITLE
feat: move public search pages to /topics/ from /searches/topics/

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -19,6 +19,7 @@ from django.contrib import admin
 from django.urls import URLPattern, URLResolver, include, path
 
 from apikeys.urls import internal_urlpatterns as apikeys_internal
+from searches.views import public_search_detail, public_search_list
 from users.views import datasette_auth, login_view
 
 from . import views
@@ -40,5 +41,8 @@ urlpatterns: list[URLPattern | URLResolver] = [
     path("notebooks/", include("notebooks.urls")),
     path("notifications/", include("notifications.urls")),
     path("searches/", include("searches.urls")),
+    # Public topics - moved to root level
+    path("topics/", public_search_list, name="public-search-list"),
+    path("topics/<slug:slug>/", public_search_detail, name="public-search-detail"),
     path("users/", include("users.urls")),
 ]

--- a/searches/models.py
+++ b/searches/models.py
@@ -380,7 +380,7 @@ class PublicSearchPage(TimeStampedModel):
         return f"{status} {self.title} (/topics/{self.slug}/)"
 
     def get_absolute_url(self) -> str:
-        return reverse("searches:public-search-detail", kwargs={"slug": self.slug})
+        return reverse("public-search-detail", kwargs={"slug": self.slug})
 
     def get_scope_description(self) -> str:
         """Human-readable description of admin-set scope limits."""

--- a/searches/urls.py
+++ b/searches/urls.py
@@ -6,8 +6,6 @@ from .views import (
     SavedSearchCRUDView,
     SavedSearchEditView,
     municipality_search,
-    public_search_detail,
-    public_search_list,
     save_search_from_params,
     saved_search_email_preview,
 )
@@ -15,9 +13,6 @@ from .views import (
 app_name = "searches"
 
 urlpatterns = [
-    # Public search pages
-    path("topics/", public_search_list, name="public-search-list"),
-    path("topics/<slug:slug>/", public_search_detail, name="public-search-detail"),
     # Saved searches (authenticated users)
     path("", SavedSearchCRUDView.as_view(role=Role.LIST), name="savedsearch-list"),
     path(


### PR DESCRIPTION
## Summary
- Moves public topic pages from `/searches/topics/` to `/topics/` for cleaner URLs
- Updates URL routing to register topics at root level
- Updates `PublicSearchPage.get_absolute_url()` to use non-namespaced URL name

## Changes
1. **config/urls.py**: Added topics URLs at root level, imported public search views
2. **searches/models.py**: Updated `get_absolute_url()` from `searches:public-search-detail` to `public-search-detail`
3. **searches/urls.py**: Removed topics URLs (moved to root)

## Test Plan
- [x] Django system checks pass (`manage.py check`)
- [x] Pre-commit hooks pass
- [x] URL structure is cleaner and more user-friendly

## Example URLs
- Before: `/searches/topics/climate-change/`
- After: `/topics/climate-change/`