### PR TITLE
feat: auto-execute search on public topic pages

### DIFF
--- a/searches/views.py
+++ b/searches/views.py
@@ -399,6 +399,7 @@ def public_search_detail(request, slug):
         "public_page": page,
         "lock_search_term": page.lock_search_term,
         "has_query": bool(page.search.search_term),
+        "auto_execute_search": True,  # Auto-execute search on page load for public pages
     }
 
     return render(request, "meetings/meeting_search.html", context)

--- a/templates/meetings/meeting_search.html
+++ b/templates/meetings/meeting_search.html
@@ -668,9 +668,10 @@
             const queryInput = document.getElementById('id_query');
             const resultsContainer = document.getElementById('search-results');
 
-            // Trigger search on page load if there are existing params
+            // Trigger search on page load if there are existing params OR if this is a public page
             const urlParams = new URLSearchParams(window.location.search);
             const hasParams = urlParams.has('query') || urlParams.has('meeting_name_query') || urlParams.has('municipalities') || urlParams.has('states') || urlParams.has('date_from') || urlParams.has('date_to') || urlParams.has('document_type');
+            const autoExecute = {{ auto_execute_search|default:"false"|lower }};
 
             // Auto-expand advanced filters if any advanced filter params are present
             // Note: municipalities and states are now outside the drawer, so only check for date range, document type, and meeting name
@@ -704,7 +705,7 @@
                 }
             }
 
-            if (hasParams) {
+            if (hasParams || autoExecute) {
                 triggerSearch();
             }
 


### PR DESCRIPTION
## Summary
- Public topic pages now automatically execute the search on page load
- Users see results immediately without needing to click the Search button
- Improves UX for curated public pages where the search term is already fixed

## Changes
1. **searches/views.py**: Add `auto_execute_search=True` to context for public search pages
2. **templates/meetings/meeting_search.html**: Update JavaScript to check for auto-execute flag and trigger search on load

## Behavior
- **Before**: Users land on public topic page and see "Start Searching" empty state, must click Search button
- **After**: Users land on public topic page and immediately see search results for the topic

## Technical Details
- Uses existing HTMX form submission mechanism
- Integrates cleanly with existing URL parameter-based auto-execution logic
- Falls back gracefully if HTMX isn't loaded yet

## Test Plan
- [x] Django system checks pass
- [x] Pre-commit hooks pass
- Manual testing: Visit a public topic page and verify results appear immediately