### PR TITLE
fix: use explicit if/else for autoExecute boolean in JavaScript

### DIFF
--- a/searches/views.py
+++ b/searches/views.py
@@ -399,6 +399,7 @@ def public_search_detail(request, slug):
         "public_page": page,
         "lock_search_term": page.lock_search_term,
         "has_query": bool(page.search.search_term),
+        "auto_execute_search": True,  # Auto-execute search on page load for public pages
     }
 
     return render(request, "meetings/meeting_search.html", context)

--- a/templates/meetings/meeting_search.html
+++ b/templates/meetings/meeting_search.html
@@ -668,9 +668,10 @@
             const queryInput = document.getElementById('id_query');
             const resultsContainer = document.getElementById('search-results');
 
-            // Trigger search on page load if there are existing params
+            // Trigger search on page load if there are existing params OR if this is a public page
             const urlParams = new URLSearchParams(window.location.search);
             const hasParams = urlParams.has('query') || urlParams.has('meeting_name_query') || urlParams.has('municipalities') || urlParams.has('states') || urlParams.has('date_from') || urlParams.has('date_to') || urlParams.has('document_type');
+            const autoExecute = {{ auto_execute_search|default:"false"|lower }};
 
             // Auto-expand advanced filters if any advanced filter params are present
             // Note: municipalities and states are now outside the drawer, so only check for date range, document type, and meeting name
@@ -704,7 +705,7 @@
                 }
             }
 
-            if (hasParams) {
+            if (hasParams || autoExecute) {
                 triggerSearch();
             }
 

--- a/templates/meetings/meeting_search.html
+++ b/templates/meetings/meeting_search.html
@@ -671,7 +671,7 @@
             // Trigger search on page load if there are existing params OR if this is a public page
             const urlParams = new URLSearchParams(window.location.search);
             const hasParams = urlParams.has('query') || urlParams.has('meeting_name_query') || urlParams.has('municipalities') || urlParams.has('states') || urlParams.has('date_from') || urlParams.has('date_to') || urlParams.has('document_type');
-            const autoExecute = {{ auto_execute_search|default:"false"|lower }};
+            const autoExecute = {% if auto_execute_search %}true{% else %}false{% endif %};
 
             // Auto-expand advanced filters if any advanced filter params are present
             // Note: municipalities and states are now outside the drawer, so only check for date range, document type, and meeting name


### PR DESCRIPTION
## Problem
The auto-execute feature deployed but isn't working in production. The issue is with how the Python boolean is rendered in JavaScript.

## Root Cause
The template used `{{ auto_execute_search|default:"false"|lower }}` which:
- Renders Python's `True` as the string `"True"`
- The `lower` filter makes it `"true"` (a string, not boolean)
- JavaScript treats non-empty strings as truthy, but the comparison logic needs an actual boolean

## Solution
Changed to explicit `{% if auto_execute_search %}true{% else %}false{% endif %}` which:
- Renders actual JavaScript boolean literals `true` or `false`
- Works correctly in boolean expressions

## Testing
- View source on a public topic page and verify `const autoExecute = true;` (not `"true"`)
- Visit `/topics/[slug]/` and confirm search executes automatically