### PR TITLE
fix: use explicit if/else for autoExecute boolean in JavaScript

### DIFF
--- a/templates/meetings/meeting_search.html
+++ b/templates/meetings/meeting_search.html
@@ -671,7 +671,7 @@
             // Trigger search on page load if there are existing params OR if this is a public page
             const urlParams = new URLSearchParams(window.location.search);
             const hasParams = urlParams.has('query') || urlParams.has('meeting_name_query') || urlParams.has('municipalities') || urlParams.has('states') || urlParams.has('date_from') || urlParams.has('date_to') || urlParams.has('document_type');
-            const autoExecute = {{ auto_execute_search|default:"false"|lower }};
+            const autoExecute = {% if auto_execute_search %}true{% else %}false{% endif %};
 
             // Auto-expand advanced filters if any advanced filter params are present
             // Note: municipalities and states are now outside the drawer, so only check for date range, document type, and meeting name


### PR DESCRIPTION
## Problem
The auto-execute feature deployed but isn't working in production. The issue is with how the Python boolean is rendered in JavaScript.

## Root Cause
The template uses `{{ auto_execute_search|default:"false"|lower }}` which:
- Renders Python's `True` as the string `"True"`
- The `lower` filter makes it `"true"` (a string, not a boolean)
- JavaScript's condition `if (hasParams || autoExecute)` needs an actual boolean

## Solution
Changed line 674 to use explicit `{% if auto_execute_search %}true{% else %}false{% endif %}` which:
- Renders actual JavaScript boolean literals `true` or `false`
- Works correctly in boolean expressions

## Testing
- View source on a public topic page and verify `const autoExecute = true;` (not `"true"`)
- Visit `/topics/[slug]/` and confirm search executes automatically on page load