### PR TITLE
debug: add console logging for auto-execute troubleshooting

### DIFF
--- a/templates/meetings/meeting_search.html
+++ b/templates/meetings/meeting_search.html
@@ -673,6 +673,8 @@
             const hasParams = urlParams.has('query') || urlParams.has('meeting_name_query') || urlParams.has('municipalities') || urlParams.has('states') || urlParams.has('date_from') || urlParams.has('date_to') || urlParams.has('document_type');
             const autoExecute = {% if auto_execute_search %}true{% else %}false{% endif %};
 
+            console.log('[Auto-Execute Debug] hasParams:', hasParams, 'autoExecute:', autoExecute);
+
             // Auto-expand advanced filters if any advanced filter params are present
             // Note: municipalities and states are now outside the drawer, so only check for date range, document type, and meeting name
             const hasAdvancedParams = urlParams.has('date_from') || urlParams.has('date_to') || urlParams.has('document_type') || urlParams.has('meeting_name_query');
@@ -688,17 +690,20 @@
 
             // Function to trigger search with HTMX (with fallback)
             function triggerSearch() {
+                console.log('[Auto-Execute Debug] Triggering search, htmx available:', typeof htmx !== 'undefined');
                 // Check if HTMX is loaded and ready
                 if (typeof htmx !== 'undefined' && htmx.trigger) {
+                    console.log('[Auto-Execute Debug] Using HTMX trigger');
                     htmx.trigger('#search-form', 'submit');
                 } else {
                     // HTMX not loaded - wait a bit and retry, or fall back to form submit
+                    console.log('[Auto-Execute Debug] HTMX not ready, waiting 500ms...');
                     setTimeout(() => {
                         if (typeof htmx !== 'undefined' && htmx.trigger) {
+                            console.log('[Auto-Execute Debug] HTMX ready after delay, triggering');
                             htmx.trigger('#search-form', 'submit');
                         } else {
                             // Final fallback: submit the form normally
-                            // The view will redirect back with params and try again
                             console.warn('HTMX not available, falling back to regular form submission');
                         }
                     }, 500);
@@ -706,7 +711,10 @@
             }
 
             if (hasParams || autoExecute) {
+                console.log('[Auto-Execute Debug] Condition met, calling triggerSearch()');
                 triggerSearch();
+            } else {
+                console.log('[Auto-Execute Debug] Condition NOT met, not triggering search');
             }
 
             // Keyboard shortcut: / to focus search

--- a/templates/meetings/meeting_search.html
+++ b/templates/meetings/meeting_search.html
@@ -671,7 +671,7 @@
             // Trigger search on page load if there are existing params OR if this is a public page
             const urlParams = new URLSearchParams(window.location.search);
             const hasParams = urlParams.has('query') || urlParams.has('meeting_name_query') || urlParams.has('municipalities') || urlParams.has('states') || urlParams.has('date_from') || urlParams.has('date_to') || urlParams.has('document_type');
-            const autoExecute = {{ auto_execute_search|default:"false"|lower }};
+            const autoExecute = {% if auto_execute_search %}true{% else %}false{% endif %};
 
             // Auto-expand advanced filters if any advanced filter params are present
             // Note: municipalities and states are now outside the drawer, so only check for date range, document type, and meeting name


### PR DESCRIPTION
## Purpose
This PR adds debug console.log statements to help diagnose why auto-execute isn't working in production.

## What it logs
- `hasParams` and `autoExecute` values
- Whether the condition `if (hasParams || autoExecute)` is met
- HTMX availability status
- When HTMX trigger is called

## How to use
1. Merge and deploy this
2. Visit a public topic page (e.g., `/topics/housing/`)
3. Open browser console (F12)
4. Look for `[Auto-Execute Debug]` messages
5. Share the console output to identify the issue

## After debugging
Once we identify the issue, we'll:
1. Fix the root cause
2. Remove these debug statements
3. Close this PR

This is temporary debugging code.