### PR TITLE
fix: use form.requestSubmit() instead of htmx.trigger for auto-execute

### DIFF
--- a/templates/meetings/meeting_search.html
+++ b/templates/meetings/meeting_search.html
@@ -673,6 +673,8 @@
             const hasParams = urlParams.has('query') || urlParams.has('meeting_name_query') || urlParams.has('municipalities') || urlParams.has('states') || urlParams.has('date_from') || urlParams.has('date_to') || urlParams.has('document_type');
             const autoExecute = {% if auto_execute_search %}true{% else %}false{% endif %};
 
+            console.log('[Auto-Execute Debug] hasParams:', hasParams, 'autoExecute:', autoExecute);
+
             // Auto-expand advanced filters if any advanced filter params are present
             // Note: municipalities and states are now outside the drawer, so only check for date range, document type, and meeting name
             const hasAdvancedParams = urlParams.has('date_from') || urlParams.has('date_to') || urlParams.has('document_type') || urlParams.has('meeting_name_query');
@@ -688,17 +690,20 @@
 
             // Function to trigger search with HTMX (with fallback)
             function triggerSearch() {
+                console.log('[Auto-Execute Debug] Triggering search, htmx available:', typeof htmx !== 'undefined');
                 // Check if HTMX is loaded and ready
                 if (typeof htmx !== 'undefined' && htmx.trigger) {
+                    console.log('[Auto-Execute Debug] Using HTMX trigger');
                     htmx.trigger('#search-form', 'submit');
                 } else {
                     // HTMX not loaded - wait a bit and retry, or fall back to form submit
+                    console.log('[Auto-Execute Debug] HTMX not ready, waiting 500ms...');
                     setTimeout(() => {
                         if (typeof htmx !== 'undefined' && htmx.trigger) {
+                            console.log('[Auto-Execute Debug] HTMX ready after delay, triggering');
                             htmx.trigger('#search-form', 'submit');
                         } else {
                             // Final fallback: submit the form normally
-                            // The view will redirect back with params and try again
                             console.warn('HTMX not available, falling back to regular form submission');
                         }
                     }, 500);
@@ -706,7 +711,10 @@
             }
 
             if (hasParams || autoExecute) {
+                console.log('[Auto-Execute Debug] Condition met, calling triggerSearch()');
                 triggerSearch();
+            } else {
+                console.log('[Auto-Execute Debug] Condition NOT met, not triggering search');
             }
 
             // Keyboard shortcut: / to focus search

--- a/templates/meetings/meeting_search.html
+++ b/templates/meetings/meeting_search.html
@@ -691,20 +691,31 @@
             // Function to trigger search with HTMX (with fallback)
             function triggerSearch() {
                 console.log('[Auto-Execute Debug] Triggering search, htmx available:', typeof htmx !== 'undefined');
+                const formElement = document.getElementById('search-form');
+
+                if (!formElement) {
+                    console.error('[Auto-Execute Debug] Form element not found!');
+                    return;
+                }
+
                 // Check if HTMX is loaded and ready
-                if (typeof htmx !== 'undefined' && htmx.trigger) {
-                    console.log('[Auto-Execute Debug] Using HTMX trigger');
-                    htmx.trigger('#search-form', 'submit');
+                if (typeof htmx !== 'undefined') {
+                    console.log('[Auto-Execute Debug] Using HTMX - triggering request directly');
+                    // Trigger HTMX request by dispatching htmx:trigger event or using form.requestSubmit()
+                    // Since HTMX intercepts form submissions, we can just submit the form
+                    // and HTMX will handle it via its hx-get attribute
+                    formElement.requestSubmit();
                 } else {
                     // HTMX not loaded - wait a bit and retry, or fall back to form submit
                     console.log('[Auto-Execute Debug] HTMX not ready, waiting 500ms...');
                     setTimeout(() => {
-                        if (typeof htmx !== 'undefined' && htmx.trigger) {
+                        if (typeof htmx !== 'undefined') {
                             console.log('[Auto-Execute Debug] HTMX ready after delay, triggering');
-                            htmx.trigger('#search-form', 'submit');
+                            formElement.requestSubmit();
                         } else {
                             // Final fallback: submit the form normally
                             console.warn('HTMX not available, falling back to regular form submission');
+                            formElement.submit();
                         }
                     }, 500);
                 }


### PR DESCRIPTION
## Problem
Auto-execute wasn't working even though all the debug logs showed the code was executing correctly. The debug logs showed:
- `autoExecute: true` ✓
- Condition met ✓
- HTMX available ✓
- `htmx.trigger()` called ✓

But the search didn't execute.

## Root Cause
`htmx.trigger('#search-form', 'submit')` doesn't work the way we expected. This function is meant to trigger custom HTMX events, not form submissions.

When a form has `hx-get`, HTMX intercepts the browser's native form submission event. We were calling `htmx.trigger()` which doesn't actually fire the submit event that HTMX listens for.

## Solution
Changed to use `formElement.requestSubmit()` which:
- Fires the browser's native submit event
- Triggers form validation
- HTMX intercepts this event and processes the `hx-get` request
- Falls back to `formElement.submit()` if HTMX isn't loaded

## Testing
- Visit a public topic page (e.g., `/topics/housing/`)
- Search results should appear immediately on page load
- Console will show debug logs confirming the flow

## Next Steps
Once confirmed working, we should remove the debug console.log statements in a follow-up PR.