### PR TITLE
fix: use form.requestSubmit() instead of htmx.trigger for auto-execute

### DIFF
--- a/templates/meetings/meeting_search.html
+++ b/templates/meetings/meeting_search.html
@@ -691,20 +691,30 @@
             // Function to trigger search with HTMX (with fallback)
             function triggerSearch() {
                 console.log('[Auto-Execute Debug] Triggering search, htmx available:', typeof htmx !== 'undefined');
+                const formElement = document.getElementById('search-form');
+
+                if (!formElement) {
+                    console.error('[Auto-Execute Debug] Form element not found!');
+                    return;
+                }
+
                 // Check if HTMX is loaded and ready
-                if (typeof htmx !== 'undefined' && htmx.trigger) {
-                    console.log('[Auto-Execute Debug] Using HTMX trigger');
-                    htmx.trigger('#search-form', 'submit');
+                if (typeof htmx !== 'undefined') {
+                    console.log('[Auto-Execute Debug] Using HTMX - triggering request via form.requestSubmit()');
+                    // Trigger HTMX request by submitting the form
+                    // HTMX will intercept the submit event and handle it via the hx-get attribute
+                    formElement.requestSubmit();
                 } else {
                     // HTMX not loaded - wait a bit and retry, or fall back to form submit
                     console.log('[Auto-Execute Debug] HTMX not ready, waiting 500ms...');
                     setTimeout(() => {
-                        if (typeof htmx !== 'undefined' && htmx.trigger) {
-                            console.log('[Auto-Execute Debug] HTMX ready after delay, triggering');
-                            htmx.trigger('#search-form', 'submit');
+                        if (typeof htmx !== 'undefined') {
+                            console.log('[Auto-Execute Debug] HTMX ready after delay, triggering via requestSubmit()');
+                            formElement.requestSubmit();
                         } else {
                             // Final fallback: submit the form normally
                             console.warn('HTMX not available, falling back to regular form submission');
+                            formElement.submit();
                         }
                     }, 500);
                 }


### PR DESCRIPTION
## Problem
Auto-execute wasn't working even though all the debug logs showed the code was executing correctly. The debug logs from production showed:
- `autoExecute: true` ✓
- Condition met ✓
- HTMX available ✓
- `htmx.trigger()` called ✓

But the search didn't execute.

## Root Cause
`htmx.trigger('#search-form', 'submit')` doesn't work for triggering form submissions. This HTMX function is for triggering custom HTMX events, not browser form submission events.

When a form has `hx-get`, HTMX intercepts the browser's native form submission event. We were calling `htmx.trigger()` which doesn't fire the submit event that HTMX listens for.

## Solution
Changed to use `formElement.requestSubmit()` which:
- Fires the browser's native submit event
- Triggers form validation
- HTMX intercepts this event and processes the `hx-get` request
- Falls back to `formElement.submit()` if HTMX isn't loaded

## Testing
- Visit a public topic page (e.g., `/topics/housing/`)
- Search results should appear immediately on page load
- Console will show: `[Auto-Execute Debug] Using HTMX - triggering request via form.requestSubmit()`

## Next Steps
Once confirmed working, we should remove the debug console.log statements in a follow-up PR.