### PR TITLE
debug: add form data logging to diagnose redirect issue

### DIFF
--- a/templates/meetings/meeting_search.html
+++ b/templates/meetings/meeting_search.html
@@ -698,6 +698,15 @@
                     return;
                 }
 
+                // Debug: Check form data
+                const formData = new FormData(formElement);
+                console.log('[Auto-Execute Debug] Form data:');
+                for (let [key, value] of formData.entries()) {
+                    console.log(`  ${key}: ${value}`);
+                }
+                console.log('[Auto-Execute Debug] Form action:', formElement.action);
+                console.log('[Auto-Execute Debug] Form hx-get:', formElement.getAttribute('hx-get'));
+
                 // Check if HTMX is loaded and ready
                 if (typeof htmx !== 'undefined') {
                     console.log('[Auto-Execute Debug] Using HTMX - triggering request via form.requestSubmit()');

--- a/templates/meetings/meeting_search.html
+++ b/templates/meetings/meeting_search.html
@@ -691,20 +691,30 @@
             // Function to trigger search with HTMX (with fallback)
             function triggerSearch() {
                 console.log('[Auto-Execute Debug] Triggering search, htmx available:', typeof htmx !== 'undefined');
+                const formElement = document.getElementById('search-form');
+
+                if (!formElement) {
+                    console.error('[Auto-Execute Debug] Form element not found!');
+                    return;
+                }
+
                 // Check if HTMX is loaded and ready
-                if (typeof htmx !== 'undefined' && htmx.trigger) {
-                    console.log('[Auto-Execute Debug] Using HTMX trigger');
-                    htmx.trigger('#search-form', 'submit');
+                if (typeof htmx !== 'undefined') {
+                    console.log('[Auto-Execute Debug] Using HTMX - triggering request via form.requestSubmit()');
+                    // Trigger HTMX request by submitting the form
+                    // HTMX will intercept the submit event and handle it via the hx-get attribute
+                    formElement.requestSubmit();
                 } else {
                     // HTMX not loaded - wait a bit and retry, or fall back to form submit
                     console.log('[Auto-Execute Debug] HTMX not ready, waiting 500ms...');
                     setTimeout(() => {
-                        if (typeof htmx !== 'undefined' && htmx.trigger) {
-                            console.log('[Auto-Execute Debug] HTMX ready after delay, triggering');
-                            htmx.trigger('#search-form', 'submit');
+                        if (typeof htmx !== 'undefined') {
+                            console.log('[Auto-Execute Debug] HTMX ready after delay, triggering via requestSubmit()');
+                            formElement.requestSubmit();
                         } else {
                             // Final fallback: submit the form normally
                             console.warn('HTMX not available, falling back to regular form submission');
+                            formElement.submit();
                         }
                     }, 500);
                 }


### PR DESCRIPTION
## Problem
After deploying the auto-execute fix (PR #64), the page immediately redirects to login instead of showing search results.

## Debug Plan
This PR adds logging to show:
- All form field values (including `public_page_slug`)
- Form action URL
- Form `hx-get` attribute

## How to Use
1. Merge and deploy
2. Visit a public topic page
3. Check console for `[Auto-Execute Debug] Form data:` output
4. Share the console output

This will tell us if `public_page_slug` is being included in the form submission or if it's missing (which would cause the redirect to login).