### PR TITLE
fix: force-include public_page_slug in HTMX requests using hx-vals

### DIFF
--- a/templates/meetings/meeting_search.html
+++ b/templates/meetings/meeting_search.html
@@ -62,6 +62,7 @@
                           hx-target="#search-results"
                           hx-swap="innerHTML show:top"
                           hx-indicator="#search-loading"
+                          {% if public_page %}hx-vals='{"public_page_slug": "{{ public_page.slug }}"}'{% endif %}
                           aria-label="Meeting document search filters"
                           role="search">
 


### PR DESCRIPTION
## Problem
After deploying auto-execute (PR #64), public topic pages immediately redirect to login instead of showing search results.

## Root Cause
When triggering the search via `form.requestSubmit()`, the hidden input field `public_page_slug` wasn't being reliably included in the HTMX request. Without this parameter, the security check in `meeting_page_search_results` view treats it as an unauthenticated request and redirects to login.

## Solution
Use HTMX's `hx-vals` attribute to explicitly include `public_page_slug` in all HTMX requests for public pages:
```django
{% if public_page %}hx-vals='{"public_page_slug": "{{ public_page.slug }}"}'{% endif %}
```

This ensures the parameter is always sent with HTMX requests, regardless of how the form is submitted (button click or programmatic `requestSubmit()`).

## Testing
- Visit a public topic page (e.g., `/topics/housing/`)
- Should NOT redirect to login
- Search results should appear immediately on page load
- Filtering should continue to work

## Additional Notes
The hidden input field remains for non-HTMX fallback scenarios. `hx-vals` supplements it for HTMX requests.