### PR TITLE
fix: use htmx.ajax() directly instead of form submission for auto-execute

### DIFF
--- a/templates/meetings/meeting_search.html
+++ b/templates/meetings/meeting_search.html
@@ -62,6 +62,7 @@
                           hx-target="#search-results"
                           hx-swap="innerHTML show:top"
                           hx-indicator="#search-loading"
+                          {% if public_page %}hx-vals='{"public_page_slug": "{{ public_page.slug }}"}'{% endif %}
                           aria-label="Meeting document search filters"
                           role="search">
 

--- a/templates/meetings/meeting_search.html
+++ b/templates/meetings/meeting_search.html
@@ -700,18 +700,36 @@
                 }
 
                 // Check if HTMX is loaded and ready
-                if (typeof htmx !== 'undefined') {
-                    console.log('[Auto-Execute Debug] Using HTMX - triggering request via form.requestSubmit()');
-                    // Trigger HTMX request by submitting the form
-                    // HTMX will intercept the submit event and handle it via the hx-get attribute
-                    formElement.requestSubmit();
+                if (typeof htmx !== 'undefined' && htmx.ajax) {
+                    console.log('[Auto-Execute Debug] Using HTMX.ajax() directly to bypass form submission');
+                    // Use HTMX ajax directly to avoid form submission issues
+                    // Build URL with query params from form
+                    const formData = new FormData(formElement);
+                    const params = new URLSearchParams(formData);
+                    const url = formElement.getAttribute('hx-get') || formElement.action;
+                    const fullUrl = url + '?' + params.toString();
+
+                    console.log('[Auto-Execute Debug] Making HTMX request to:', fullUrl);
+
+                    htmx.ajax('GET', fullUrl, {
+                        target: '#search-results',
+                        swap: 'innerHTML show:top'
+                    });
                 } else {
                     // HTMX not loaded - wait a bit and retry, or fall back to form submit
                     console.log('[Auto-Execute Debug] HTMX not ready, waiting 500ms...');
                     setTimeout(() => {
-                        if (typeof htmx !== 'undefined') {
-                            console.log('[Auto-Execute Debug] HTMX ready after delay, triggering via requestSubmit()');
-                            formElement.requestSubmit();
+                        if (typeof htmx !== 'undefined' && htmx.ajax) {
+                            console.log('[Auto-Execute Debug] HTMX ready after delay, triggering via ajax()');
+                            const formData = new FormData(formElement);
+                            const params = new URLSearchParams(formData);
+                            const url = formElement.getAttribute('hx-get') || formElement.action;
+                            const fullUrl = url + '?' + params.toString();
+
+                            htmx.ajax('GET', fullUrl, {
+                                target: '#search-results',
+                                swap: 'innerHTML show:top'
+                            });
                         } else {
                             // Final fallback: submit the form normally
                             console.warn('HTMX not available, falling back to regular form submission');


### PR DESCRIPTION
## Problem
After merging PR #66, still seeing redirect to login with malformed URL:
```
/login/?next=/meetings/search/%3Fpublic_page_slug%3Dflock%26query%3D...
```

## Root Cause
`form.requestSubmit()` triggers a full page navigation before HTMX event listeners are ready to intercept it. The browser handles the form submission, leading to:
- Full page reload attempt
- Malformed query parameters (double-encoded `%3F`)
- Authentication check failure

## Solution
Use `htmx.ajax()` directly to make the request programmatically:
```javascript
const formData = new FormData(formElement);
const params = new URLSearchParams(formData);
const fullUrl = url + '?' + params.toString();

htmx.ajax('GET', fullUrl, {
    target: '#search-results',
    swap: 'innerHTML show:top'
});
```

This bypasses form submission entirely and gives us full control over the HTMX request.

## Benefits
- HTMX handles request from start (no browser interception)
- All form data included (public_page_slug from hidden input)
- No page navigation
- Correct content targeting and swapping

## Testing
Console should show: `[Auto-Execute Debug] Using HTMX.ajax() directly to bypass form submission`