### PR TITLE
feat: show loading spinner immediately when auto-executing search

### DIFF
--- a/templates/meetings/meeting_search.html
+++ b/templates/meetings/meeting_search.html
@@ -702,6 +702,25 @@
                 // Check if HTMX is loaded and ready
                 if (typeof htmx !== 'undefined' && htmx.ajax) {
                     console.log('[Auto-Execute Debug] Using HTMX.ajax() directly to bypass form submission');
+
+                    // Show loading spinner immediately
+                    const loadingHTML = `
+                        <div class="loading-overlay" role="alert" aria-live="assertive">
+                            <div class="text-center">
+                                <svg class="inline-block animate-spin h-12 w-12 text-indigo-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                                </svg>
+                                <p class="mt-4 text-sm font-medium text-gray-700">Searching meeting documents...</p>
+                                <p class="mt-1 text-xs text-gray-500">This may take a few moments</p>
+                                <span class="sr-only">Loading results, please wait</span>
+                            </div>
+                        </div>
+                    `;
+                    if (!resultsContainer.querySelector('.loading-overlay')) {
+                        resultsContainer.insertAdjacentHTML('afterbegin', loadingHTML);
+                    }
+
                     // Use HTMX ajax directly to avoid form submission issues
                     // Build URL with query params from form
                     const formData = new FormData(formElement);
@@ -718,6 +737,25 @@
                 } else {
                     // HTMX not loaded - wait a bit and retry, or fall back to form submit
                     console.log('[Auto-Execute Debug] HTMX not ready, waiting 500ms...');
+
+                    // Show loading spinner while waiting
+                    const loadingHTML = `
+                        <div class="loading-overlay" role="alert" aria-live="assertive">
+                            <div class="text-center">
+                                <svg class="inline-block animate-spin h-12 w-12 text-indigo-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                                </svg>
+                                <p class="mt-4 text-sm font-medium text-gray-700">Searching meeting documents...</p>
+                                <p class="mt-1 text-xs text-gray-500">This may take a few moments</p>
+                                <span class="sr-only">Loading results, please wait</span>
+                            </div>
+                        </div>
+                    `;
+                    if (!resultsContainer.querySelector('.loading-overlay')) {
+                        resultsContainer.insertAdjacentHTML('afterbegin', loadingHTML);
+                    }
+
                     setTimeout(() => {
                         if (typeof htmx !== 'undefined' && htmx.ajax) {
                             console.log('[Auto-Execute Debug] HTMX ready after delay, triggering via ajax()');


### PR DESCRIPTION
## Summary
Shows the loading spinner immediately when auto-executing search on public topic pages, providing instant visual feedback.

## Changes
- Inject the loading overlay HTML before making the HTMX request
- Applies to both immediate execution and delayed (HTMX not ready) paths
- Uses the same loading overlay HTML that's used for normal searches

## User Experience
**Before**: 
- Page loads
- Brief flash of "Start Searching" empty state
- Results appear

**After**:
- Page loads
- Loading spinner appears immediately
- Results replace spinner

This eliminates the jarring empty state flash and provides clear feedback that content is loading.

## Testing
Visit a public topic page and verify:
- Loading spinner appears immediately on page load
- Spinner shows "Searching meeting documents..." message
- Results replace the spinner when loaded