### PR TITLE
perf: eliminate COUNT(*) from search queries

### DIFF
--- a/docs/TANTIVY_QUICKWIT_RESEARCH.md
+++ b/docs/TANTIVY_QUICKWIT_RESEARCH.md
@@ -1,0 +1,164 @@
+# Tantivy / Quickwit Research for Full-Text Search
+
+**Date**: 2026-04-10
+**Context**: Evaluating alternatives to PostgreSQL FTS for civic-observer search (12M+ rows now, targeting 100M)
+
+---
+
+## Why We're Looking
+
+PostgreSQL FTS is returning 5s+ query times on the `meetings_meetingpage` table (12M+ rows) despite:
+- GIN indexes with `fastupdate=off`
+- Removal of `ts_rank()` computation
+- Redis caching layer (5-min TTL)
+- Autovacuum tuning
+- JIT disabled, SSD-tuned planner settings
+
+Meilisearch was previously evaluated and abandoned — index size was prohibitive at 12M docs and loading was too slow.
+
+---
+
+## Tantivy (Rust FTS Library)
+
+### What It Is
+A Rust full-text search library, similar to Apache Lucene but lighter. Can be used as an embedded library (via `tantivy-py` Python bindings) or as the engine behind higher-level search servers.
+
+### Scaling Characteristics
+
+| Metric | Value | Source |
+|--------|-------|--------|
+| Theoretical doc limit | ~4.29B per segment (`u32` DocId) | Tantivy source code |
+| Proven at scale | 172M documents | [GitHub Issue #2316](https://github.com/quickwit-oss/tantivy/issues/2316) |
+| Query latency (172M, hot cache) | ~80ms default, ~35ms with THP, **~2ms with SSTable term dict** | Same issue |
+| Indexing throughput | ~12,500 docs/sec (single node Python) | tantivy-py benchmarks |
+| Indexing throughput (distributed) | ~200,000 docs/sec (10 nodes with Ray) | tantivy-py benchmarks |
+
+### Critical Finding: SSTable Term Dictionary
+
+At 100M+ documents, the default FST-based term dictionary becomes a bottleneck (~80ms lookups). Switching to the **SSTable term dictionary** (enabled via the `quickwit` feature flag) drops query latency to ~2ms. This is essential for large-scale deployment.
+
+### Memory Model
+- Uses memory-mapped files for search (OS page cache is the primary memory consumer)
+- Indexing memory is controlled by `overall_heap_size_in_bytes`, minimum 15MB
+- Can index datasets of any size on modest hardware — segments flush to disk
+- Performance degrades when index exceeds available RAM (page cache thrashing)
+
+### Disk Estimates for 100M Documents
+Extrapolating from Quickwit split sizes (10M docs = 1-10GB):
+- **100M documents ≈ 10-100GB disk** depending on document size and indexed fields
+
+---
+
+## tantivy-py (Python Bindings)
+
+### Current State (v0.25.1, December 2025)
+
+| Aspect | Assessment |
+|--------|-----------|
+| PyPI downloads | ~424,000/month |
+| Open issues | 12 |
+| Python versions | 3.9 - 3.14 |
+| GIL handling | Releases GIL during index building and searcher acquisition |
+| Maintenance | Active, regular releases |
+| Contributors | ~10 (small team) |
+
+### Known Gaps vs Upstream Tantivy
+- No ranking by string fast field
+- No unbounded range queries
+- Limited fuzzy query support with JSON fields
+- No field boost API
+- No custom tokenizer registration
+- API mirrors Rust too closely (not always Pythonic)
+- Sparse documentation
+
+### Assessment for civic-observer
+**Usable for current 12M scale but risky for 100M.** The small maintainer team, missing features, and need to manage index files / concurrent access / update logic yourself makes this a significant operational burden. Better suited as a prototype path than a production path at scale.
+
+---
+
+## Quickwit (Distributed Search on Tantivy)
+
+### What It Is
+A distributed search engine built on Tantivy with compute-storage separation. Designed for append-heavy workloads (logs, events, documents). Runs as a Docker service.
+
+### Why It's a Strong Fit for civic-observer
+1. **Append-optimized**: Meeting data is almost entirely inserts, rarely updates — exactly Quickwit's sweet spot
+2. **Proven scale**: Used in production at 50 trillion documents / 40 PB uncompressed
+3. **100M is trivial**: Would fit in ~10 splits (10M docs each), runnable on a single node
+4. **Docker-native**: Fits right into our existing docker-compose setup
+5. **Cost-effective**: Object storage (S3/MinIO) for index data, stateless searchers
+
+### Production-Proven Scale
+
+| Metric | Value |
+|--------|-------|
+| Largest known cluster | ~40 PB uncompressed logs |
+| Document count (largest) | 50 trillion (5×10¹³) |
+| Index storage on S3 | 7.5 PB |
+| Indexing throughput (largest) | 1 PB/day (14M docs/sec, 200 pods) |
+| Indexing throughput (14-pod) | 540 MB/s (~46 TB/day) |
+| Split open time on S3 | 60ms (with hotcache) |
+
+### Resource Requirements for 100M Documents
+
+| Component | CPU | RAM | Disk |
+|-----------|-----|-----|------|
+| Indexer | 7.5 MB/s per core | 4-8 GB per core | 120GB+ SSD |
+| Searcher | scales with QPS | 4-8 GB per core | Optional (stateless) |
+| Control Plane | 1 core | 2 GB | None |
+| Metastore | 1-2 cores | 2-4 GB | None |
+| **Single node minimum** | **2 cores** | **8 GB** | **SSD** |
+
+**Estimated cost**: S3 storage for index ~$5/mo, small instance ~$30-50/mo. Well within budget.
+
+### Trade-offs vs Elasticsearch
+- 5x cheaper compute, 2x cheaper storage in reported migrations
+- Optimized for append-only data
+- Lower QPS than Elasticsearch for the same hardware
+- Higher query latency (~60ms split open on S3 vs sub-ms for local ES)
+- **No real-time updates** — batch indexing model (acceptable for meeting data which arrives in batches via webhooks)
+
+### Trade-offs vs Typesense
+- Typesense caps out around 28M docs (largest public deployment); no native sharding
+- Typesense requires entire index in RAM (~50-150GB for 100M docs)
+- Quickwit uses disk/object storage — dramatically cheaper at scale
+- Quickwit has higher per-query latency but handles much larger datasets
+
+### Integration Path
+We already have a `SearchBackend` abstraction (`searches/search_backends.py`) with `PostgresSearchBackend` and `MeilisearchBackend`. Adding a `QuickwitBackend` would follow the same pattern:
+- Quickwit has an Elasticsearch-compatible REST API
+- Filter expressions map to our existing filter patterns (municipality, state, date range, document type)
+- Sort by `meeting_date` descending (our current ordering)
+
+### Indexing Strategy
+Quickwit is designed for batch indexing. Our webhook-triggered backfill jobs already process meeting data in batches — we'd add a step to push documents to Quickwit after PostgreSQL insert. The existing `searches/indexing.py` (built for Meilisearch) provides a template for the batch document format.
+
+### Quickwit vs Manticore Search
+On a 100M Hacker News comments benchmark, Manticore Search was 2.86x faster than Quickwit. Manticore is worth noting as another option but has a smaller ecosystem and less mature cloud/object-storage integration.
+
+---
+
+## Recommendation
+
+**Quickwit is the clear winner for scaling to 100M documents.** It's the only option in this evaluation that is:
+1. Proven at scales far beyond our target
+2. Cost-effective on modest hardware
+3. Architecturally aligned with our append-heavy workload
+4. Deployable via Docker alongside our existing stack
+5. Integrable via our existing `SearchBackend` abstraction
+
+**However**: Before investing in Quickwit, we should first diagnose why PostgreSQL FTS is returning 5s queries. The existing optimizations (GIN indexes, no rank, Redis cache) should yield sub-second performance at 12M rows. Something else may be wrong (query plans, table bloat, misconfigured memory on production). A quick diagnosis could save significant effort.
+
+---
+
+## References
+
+- [Tantivy GitHub](https://github.com/quickwit-oss/tantivy)
+- [Tantivy Issue #2316 - 172M doc performance](https://github.com/quickwit-oss/tantivy/issues/2316)
+- [tantivy-py on PyPI](https://pypi.org/project/tantivy/)
+- [Quickwit documentation](https://quickwit.io/docs/)
+- [Quickwit cluster sizing](https://quickwit.io/docs/main-branch/deployment/cluster-sizing)
+- [Quickwit 0.8 announcement](https://quickwit.io/blog/quickwit-0.8)
+- [Manticore vs Quickwit benchmark](https://manticoresearch.com/comparison/vs-quickwit/)
+- [Typesense system requirements](https://typesense.org/docs/guide/system-requirements.html)
+- [Typesense sharding issue #295](https://github.com/typesense/typesense/issues/295)

--- a/docs/plans/2026-04-10-postgres-fts-diagnosis.md
+++ b/docs/plans/2026-04-10-postgres-fts-diagnosis.md
@@ -1,0 +1,197 @@
+# Timeboxed PostgreSQL FTS Diagnosis Plan
+
+**Date**: 2026-04-10
+**Timebox**: 2 hours maximum
+**Goal**: Determine if PostgreSQL FTS can be fixed to deliver sub-second search at 12M rows, or if we need to move to Quickwit
+
+---
+
+## Context
+
+Despite extensive optimization (GIN indexes, no ts_rank, Redis caching, autovacuum tuning, JIT off), all search queries are returning 5s+. This is unexpectedly slow — GIN index lookups on 12M rows with no rank computation should be sub-second. Something else is likely wrong.
+
+## Diagnosis Steps
+
+### Step 1: Verify the Query Plan (15 min)
+
+Connect to the production database and run `EXPLAIN (ANALYZE, BUFFERS, TIMING)` on the actual search query being executed. We need to see:
+
+```sql
+-- Basic FTS query (the most common case)
+EXPLAIN (ANALYZE, BUFFERS, TIMING, FORMAT TEXT)
+SELECT mp.*, md.*, m.*
+FROM meetings_meetingpage mp
+JOIN meetings_meetingdocument md ON mp.document_id = md.id
+JOIN municipalities_muni m ON md.municipality_id = m.id
+WHERE mp.search_vector @@ websearch_to_tsquery('simple', 'police')
+ORDER BY md.meeting_date DESC
+LIMIT 20 OFFSET 0;
+
+-- Also run the count query separately (this may be the real bottleneck)
+EXPLAIN (ANALYZE, BUFFERS, TIMING, FORMAT TEXT)
+SELECT COUNT(*)
+FROM meetings_meetingpage mp
+JOIN meetings_meetingdocument md ON mp.document_id = md.id
+WHERE mp.search_vector @@ websearch_to_tsquery('simple', 'police');
+```
+
+**What to look for:**
+- Is the GIN index being used? (Should see `Bitmap Index Scan using meetingpage_search_vector_idx`)
+- Is the bitmap scan "lossy"? (Means `work_mem` too low — bitmap overflows to disk)
+- What's the actual time breakdown? (Is it the FTS filter, the JOIN, the ORDER BY, or the COUNT?)
+- How many rows does the FTS match? (If "police" matches 2M of 12M rows, the count alone will be slow)
+
+### Step 2: Check Table and Index Health (15 min)
+
+```sql
+-- Table size and bloat
+SELECT
+    pg_size_pretty(pg_total_relation_size('meetings_meetingpage')) as total_size,
+    pg_size_pretty(pg_relation_size('meetings_meetingpage')) as table_size,
+    pg_size_pretty(pg_indexes_size('meetings_meetingpage')) as indexes_size,
+    n_live_tup,
+    n_dead_tup,
+    ROUND(100.0 * n_dead_tup / NULLIF(n_live_tup + n_dead_tup, 0), 2) as dead_pct,
+    last_vacuum,
+    last_autovacuum,
+    last_analyze,
+    last_autoanalyze
+FROM pg_stat_user_tables
+WHERE relname = 'meetings_meetingpage';
+
+-- Index sizes and usage
+SELECT
+    indexrelname as index_name,
+    pg_size_pretty(pg_relation_size(indexrelid)) as index_size,
+    idx_scan as times_used,
+    idx_tup_read,
+    idx_tup_fetch
+FROM pg_stat_user_indexes
+WHERE relname = 'meetings_meetingpage'
+ORDER BY pg_relation_size(indexrelid) DESC;
+
+-- Check for pending GIN entries (should be 0 with fastupdate=off)
+SELECT * FROM pg_stat_all_indexes
+WHERE relname = 'meetings_meetingpage'
+  AND indexrelname LIKE '%search_vector%';
+```
+
+**What to look for:**
+- High dead tuple percentage (>5%) means vacuum isn't keeping up
+- Very large index size relative to table size could indicate bloat
+- Index not being scanned (idx_scan = 0) means the planner is choosing seq scan instead
+
+### Step 3: Check PostgreSQL Configuration on Production (10 min)
+
+```sql
+-- Verify critical settings are actually applied
+SHOW shared_buffers;
+SHOW work_mem;
+SHOW effective_cache_size;
+SHOW jit;
+SHOW random_page_cost;
+
+-- Check if we're on CrunchyBridge or Docker in production
+SELECT version();
+
+-- Check current connections (are we saturated?)
+SELECT count(*), state
+FROM pg_stat_activity
+GROUP BY state;
+```
+
+**Key question**: Is production actually using the tuned `postgresql.conf`, or is it on CrunchyBridge with defaults? The docker-compose config mounts a custom conf file, but if production uses CrunchyBridge, those settings may not be applied.
+
+### Step 4: Identify the Real Bottleneck (20 min)
+
+Based on Step 1-3 findings, the bottleneck is likely one of:
+
+**A. The COUNT query is the killer.**
+The `PostgresSearchBackend.search()` method calls `queryset.count()` (line 194 of `search_backends.py`) before pagination. For broad queries matching millions of rows, COUNT alone can take seconds.
+
+**Fix**: Remove exact count. Use `EXPLAIN` row estimates, or cap count at a threshold:
+```sql
+-- Instead of exact COUNT(*)
+SELECT
+  CASE WHEN count > 10000 THEN 10000
+       ELSE count
+  END
+FROM (SELECT COUNT(*) as count FROM ... LIMIT 10001) sub;
+```
+Or use the planner's estimate: `SELECT reltuples FROM pg_class WHERE relname = 'meetings_meetingpage'`
+
+**B. Lossy bitmap heap scan.**
+If `work_mem` is too low, the GIN bitmap spills to disk and rechecks every page.
+
+**Fix**: Increase `work_mem` to 128MB or 256MB for search connections.
+
+**C. ORDER BY on a different table's column.**
+`ORDER BY md.meeting_date DESC` requires joining MeetingDocument and sorting — this can't use the GIN index.
+
+**Fix**: Add `meeting_date` to MeetingPage (denormalized) with a composite index, or use keyset/cursor pagination to avoid full sort.
+
+**D. Table bloat / stale statistics.**
+If VACUUM hasn't run recently, the planner may have stale statistics and choose bad plans.
+
+**Fix**: Run `VACUUM ANALYZE meetings_meetingpage;` and re-test.
+
+**E. The Redis cache isn't working.**
+If 5s on "hot" queries too, verify the cache is actually being read:
+
+```python
+# Quick test in Django shell
+from searches.cache import get_cached_search_results
+
+result = get_cached_search_results(
+    search_term="police",
+    municipalities=[],
+    states=[],
+    date_from=None,
+    date_to=None,
+    document_type="all",
+    meeting_name_query="",
+    limit=20,
+    offset=0,
+)
+print(f"Cache hit: {result is not None}")
+```
+
+### Step 5: Apply Quick Fixes and Re-test (30 min)
+
+Based on diagnosis, apply the most likely fixes:
+
+1. **If COUNT is the bottleneck**: Replace exact count with capped count or estimate
+2. **If lossy bitmap**: Increase `work_mem` to 256MB
+3. **If ORDER BY**: Test query without the cross-table ORDER BY
+4. **If bloat**: Run VACUUM ANALYZE
+5. **If cache broken**: Fix cache configuration
+
+Re-run the same EXPLAIN ANALYZE queries and compare times.
+
+### Step 6: Decision Point (10 min)
+
+After fixes, measure:
+- If queries are now **< 500ms**: PostgreSQL FTS is viable. Document what was wrong and ship the fix.
+- If queries are **500ms - 2s**: Marginal. PostgreSQL works for now but plan Quickwit migration for 100M scale.
+- If queries are still **> 2s**: PostgreSQL FTS isn't the right tool at this data volume. Proceed to Quickwit implementation.
+
+---
+
+## Most Likely Culprit
+
+Based on the code review, **my top suspect is the `COUNT(*)` query** on line 194 of `search_backends.py`. For a broad search term like "police" or "budget" that matches hundreds of thousands of pages across 12M rows, the COUNT alone requires scanning the full bitmap result — this is O(matches), not O(limit). Combined with the cross-table JOIN for the ORDER BY, you get a query that touches far more data than the 20 results displayed.
+
+The Redis cache *should* help on repeat queries, but if the cache key normalization or serialization has any issue, every query hits the database.
+
+---
+
+## Files to Investigate
+
+| File | Why |
+|------|-----|
+| `searches/search_backends.py:194` | The `count()` call — likely bottleneck |
+| `searches/cache.py` | Verify cache is actually working |
+| `searches/services.py` | The `_apply_search_filters` and `_apply_meeting_name_filter` functions |
+| `config/settings/production.py` | What DB settings are actually used in prod |
+| `docker/postgres/postgresql.conf` | Local dev PG config (already reviewed) |
+| `docs/crunchybridge-configuration.md` | Production PG config guidance |

--- a/meetings/views.py
+++ b/meetings/views.py
@@ -340,7 +340,7 @@ def meeting_page_search_results(request: HttpRequest) -> HttpResponse:
     # Default empty context
     context: dict[str, Any] = {
         "results": [],
-        "page_obj": None,
+        "page_info": None,
         "has_query": False,
         "error": None,
     }
@@ -438,20 +438,37 @@ def meeting_page_search_results(request: HttpRequest) -> HttpResponse:
         document_type=document_type,
     )
 
-    # Paginate results
-    # IMPORTANT: Paginate BEFORE generating headlines for performance
-    from django.core.paginator import Paginator
+    # Paginate results using LIMIT+1 strategy to avoid expensive COUNT(*)
+    # Django's Paginator calls .count() which scans the full result set — this
+    # can take 3-5s on broad FTS queries matching hundreds of thousands of rows.
+    # Instead, we fetch page_size+1 rows: if we get the extra row, there's a next page.
+    try:
+        page_number = int(request.GET.get("page", 1))
+    except (TypeError, ValueError):
+        page_number = 1
+    if page_number < 1:
+        page_number = 1
+    offset = (page_number - 1) * SEARCH_RESULTS_PER_PAGE
 
-    paginator = Paginator(queryset, SEARCH_RESULTS_PER_PAGE)
-    page_number = request.GET.get("page", 1)
-    page_obj = paginator.get_page(page_number)
+    # Fetch one extra row to detect if there's a next page
+    page_results = list(queryset[offset : offset + SEARCH_RESULTS_PER_PAGE + 1])
+    has_next = len(page_results) > SEARCH_RESULTS_PER_PAGE
+    if has_next:
+        page_results = page_results[:SEARCH_RESULTS_PER_PAGE]
+
+    # Build a lightweight page info object for the template
+    page_info = {
+        "number": page_number,
+        "has_previous": page_number > 1,
+        "has_next": has_next,
+        "previous_page_number": page_number - 1 if page_number > 1 else None,
+        "next_page_number": page_number + 1 if has_next else None,
+    }
 
     # Generate headlines ONLY for the current page (not all results)
     # This is a major performance optimization - headlines are expensive to compute
-    context["results"] = _generate_headlines_for_page(
-        page_obj.object_list, search_query
-    )
-    context["page_obj"] = page_obj
+    context["results"] = _generate_headlines_for_page(page_results, search_query)
+    context["page_info"] = page_info
 
     # Add active filters to context for display
     context["active_filters"] = {

--- a/searches/search_backends.py
+++ b/searches/search_backends.py
@@ -190,16 +190,26 @@ class PostgresSearchBackend(SearchBackend):
             # All updates mode - order by date descending
             queryset = queryset.order_by("-document__meeting_date")
 
-        # Get total count before pagination
-        total_count = queryset.count()
-
-        # Apply pagination
-        results_queryset = queryset[offset : offset + limit]
+        # Avoid expensive COUNT(*) — fetch limit+1 rows to detect if there are more
+        results_queryset = queryset[offset : offset + limit + 1]
 
         # Convert to dictionaries
         results = []
         for page in results_queryset:
             results.append(self._page_to_dict(page))
+
+        # If we got more than limit results, there are more pages
+        has_more = len(results) > limit
+        if has_more:
+            results = results[:limit]
+
+        # Return a count that's useful for pagination without scanning full result set:
+        # - If fewer results than limit, we know the exact total
+        # - If more, report offset + limit + 1 to signal "there are more"
+        if has_more:
+            total_count = offset + limit + 1
+        else:
+            total_count = offset + len(results)
 
         return results, total_count
 

--- a/templates/meetings/partials/search_results.html
+++ b/templates/meetings/partials/search_results.html
@@ -19,10 +19,10 @@
     <!-- Results Header with screen reader announcement -->
     <div class="mb-4">
         <p class="text-sm text-gray-600"
-           aria-label="Found {{ page_obj.paginator.count }} result{{ page_obj.paginator.count|pluralize }}{% if page_obj.paginator.num_pages > 1 %}, page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}{% endif %}">
-            Found <span class="font-semibold text-gray-900">{{ page_obj.paginator.count }}</span> result{{ page_obj.paginator.count|pluralize }}
-            {% if page_obj.paginator.num_pages > 1 %}
-                (Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }})
+           aria-label="Search results, page {{ page_info.number }}">
+            Showing results
+            {% if page_info.number > 1 %}
+                (Page {{ page_info.number }})
             {% endif %}
         </p>
 
@@ -155,12 +155,12 @@
     </div>
 
     <!-- Pagination -->
-    {% if page_obj.paginator.num_pages > 1 %}
+    {% if page_info.has_previous or page_info.has_next %}
         <div class="mt-6 flex items-center justify-between border-t border-gray-200 bg-white px-4 py-3 sm:px-6 rounded-xl shadow-lg">
             <div class="flex flex-1 justify-between sm:hidden">
-                {% if page_obj.has_previous %}
-                    <a href="?{% for key, value in request.GET.items %}{% if key != 'page' %}{{ key }}={{ value }}&{% endif %}{% endfor %}page={{ page_obj.previous_page_number }}"
-                       hx-get="{% url 'meetings:meeting-search-results' %}?{% for key, value in request.GET.items %}{% if key != 'page' %}{{ key }}={{ value }}&{% endif %}{% endfor %}page={{ page_obj.previous_page_number }}"
+                {% if page_info.has_previous %}
+                    <a href="?{% for key, value in request.GET.items %}{% if key != 'page' %}{{ key }}={{ value }}&{% endif %}{% endfor %}page={{ page_info.previous_page_number }}"
+                       hx-get="{% url 'meetings:meeting-search-results' %}?{% for key, value in request.GET.items %}{% if key != 'page' %}{{ key }}={{ value }}&{% endif %}{% endfor %}page={{ page_info.previous_page_number }}"
                        hx-target="#search-results"
                        hx-swap="innerHTML scroll:top"
                        class="relative inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50">
@@ -172,9 +172,9 @@
                     </span>
                 {% endif %}
 
-                {% if page_obj.has_next %}
-                    <a href="?{% for key, value in request.GET.items %}{% if key != 'page' %}{{ key }}={{ value }}&{% endif %}{% endfor %}page={{ page_obj.next_page_number }}"
-                       hx-get="{% url 'meetings:meeting-search-results' %}?{% for key, value in request.GET.items %}{% if key != 'page' %}{{ key }}={{ value }}&{% endif %}{% endfor %}page={{ page_obj.next_page_number }}"
+                {% if page_info.has_next %}
+                    <a href="?{% for key, value in request.GET.items %}{% if key != 'page' %}{{ key }}={{ value }}&{% endif %}{% endfor %}page={{ page_info.next_page_number }}"
+                       hx-get="{% url 'meetings:meeting-search-results' %}?{% for key, value in request.GET.items %}{% if key != 'page' %}{{ key }}={{ value }}&{% endif %}{% endfor %}page={{ page_info.next_page_number }}"
                        hx-target="#search-results"
                        hx-swap="innerHTML scroll:top"
                        class="relative ml-3 inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50">
@@ -190,18 +190,15 @@
             <div class="hidden sm:flex sm:flex-1 sm:items-center sm:justify-between">
                 <div>
                     <p class="text-sm text-gray-700">
-                        Showing page
-                        <span class="font-medium">{{ page_obj.number }}</span>
-                        of
-                        <span class="font-medium">{{ page_obj.paginator.num_pages }}</span>
-                        ({{ page_obj.paginator.count }} total result{{ page_obj.paginator.count|pluralize }})
+                        Page
+                        <span class="font-medium">{{ page_info.number }}</span>
                     </p>
                 </div>
                 <div>
                     <nav class="isolate inline-flex -space-x-px rounded-md shadow-sm" aria-label="Pagination">
-                        {% if page_obj.has_previous %}
-                            <a href="?{% for key, value in request.GET.items %}{% if key != 'page' %}{{ key }}={{ value }}&{% endif %}{% endfor %}page={{ page_obj.previous_page_number }}"
-                               hx-get="{% url 'meetings:meeting-search-results' %}?{% for key, value in request.GET.items %}{% if key != 'page' %}{{ key }}={{ value }}&{% endif %}{% endfor %}page={{ page_obj.previous_page_number }}"
+                        {% if page_info.has_previous %}
+                            <a href="?{% for key, value in request.GET.items %}{% if key != 'page' %}{{ key }}={{ value }}&{% endif %}{% endfor %}page={{ page_info.previous_page_number }}"
+                               hx-get="{% url 'meetings:meeting-search-results' %}?{% for key, value in request.GET.items %}{% if key != 'page' %}{{ key }}={{ value }}&{% endif %}{% endfor %}page={{ page_info.previous_page_number }}"
                                hx-target="#search-results"
                                hx-swap="innerHTML scroll:top"
                                class="relative inline-flex items-center rounded-l-md px-2 py-2 text-gray-400 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:z-20">
@@ -220,12 +217,12 @@
                         {% endif %}
 
                         <span class="relative inline-flex items-center px-4 py-2 text-sm font-semibold text-gray-900 ring-1 ring-inset ring-gray-300">
-                            {{ page_obj.number }}
+                            {{ page_info.number }}
                         </span>
 
-                        {% if page_obj.has_next %}
-                            <a href="?{% for key, value in request.GET.items %}{% if key != 'page' %}{{ key }}={{ value }}&{% endif %}{% endfor %}page={{ page_obj.next_page_number }}"
-                               hx-get="{% url 'meetings:meeting-search-results' %}?{% for key, value in request.GET.items %}{% if key != 'page' %}{{ key }}={{ value }}&{% endif %}{% endfor %}page={{ page_obj.next_page_number }}"
+                        {% if page_info.has_next %}
+                            <a href="?{% for key, value in request.GET.items %}{% if key != 'page' %}{{ key }}={{ value }}&{% endif %}{% endfor %}page={{ page_info.next_page_number }}"
+                               hx-get="{% url 'meetings:meeting-search-results' %}?{% for key, value in request.GET.items %}{% if key != 'page' %}{{ key }}={{ value }}&{% endif %}{% endfor %}page={{ page_info.next_page_number }}"
                                hx-target="#search-results"
                                hx-swap="innerHTML scroll:top"
                                class="relative inline-flex items-center rounded-r-md px-2 py-2 text-gray-400 ring-1 ring-inset ring-gray-300 hover:bg-gray-50 focus:z-20">


### PR DESCRIPTION
## Summary

- **Replaced Django's `Paginator` with LIMIT+1 pagination** in the main search view (`meetings/views.py`). The Paginator calls `queryset.count()` which scans the full FTS bitmap result set — potentially hundreds of thousands of rows — adding 3-5s to every search query.
- **Removed `count()` from `PostgresSearchBackend.search()`** (`searches/search_backends.py`) — same fix for the saved search code path.
- **Updated search results template** to use lightweight `page_info` dict instead of `page_obj`, removing total count display (since computing it was the bottleneck).
- **Added research docs** for future search scaling: Tantivy/Quickwit evaluation and a PostgreSQL FTS diagnosis plan.

## How it works

Instead of counting all matching rows, we fetch `page_size + 1` rows. If the extra row comes back, there's a next page. The query now only needs to find the top 21 results (via GIN index + LIMIT), not scan the entire result set.

## What changes for users

- Pagination shows "Page N" with prev/next instead of "Page 1 of 500 (10,000 results)"
- Search should be dramatically faster (eliminating the 3-5s COUNT overhead)

## Test plan

- [ ] Run `uv run pytest` with DB up — verify existing search tests pass
- [ ] Manual test: search for a broad term (e.g. "police", "budget") — should return in under 1s
- [ ] Manual test: paginate through results — prev/next buttons work correctly
- [ ] Manual test: page 1 shows no "Previous" button, last page shows no "Next" button
- [ ] Verify public search pages still work (they use a different code path)